### PR TITLE
Import TensorSpec from correct module

### DIFF
--- a/tf_agents/specs/tensor_spec.py
+++ b/tf_agents/specs/tensor_spec.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A TensorSpec class."""
+"""Utilities related to TensorSpec class."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -30,7 +30,7 @@ from tensorflow.python.framework import tensor_spec as ts  # TF internal
 nest = tf.contrib.framework.nest
 tfd = tfp.distributions
 
-TensorSpec = tf.TensorSpec
+TensorSpec = ts.TensorSpec
 BoundedTensorSpec = ts.BoundedTensorSpec
 
 


### PR DESCRIPTION
As of the most recent stable TensorFlow version (e.g. 1.12.0),
the TensorSpec class is not yet exposed into the outermost tf namespace.

```
>>> tf.TensorSpec
AttributeError: module 'tensorflow' has no attribute 'TensorSpec'
```

To have better compatibility, we can instead import the `TensorSpec`
class from `tensorflow.python.framework.tensor_spec`.