### PR TITLE
Added parallel initialization for ParallelPyEnvironment.

### DIFF
--- a/tf_agents/environments/parallel_py_environment.py
+++ b/tf_agents/environments/parallel_py_environment.py
@@ -60,6 +60,7 @@ class ParallelPyEnvironment(py_environment.PyEnvironment):
     self._envs = [ProcessPyEnvironment(ctor, flatten=flatten)
                   for ctor in env_constructors]
     self._num_envs = len(env_constructors)
+    self._blocking = blocking
     self.start()
     self._action_spec = self._envs[0].action_spec()
     self._observation_spec = self._envs[0].observation_spec()
@@ -68,13 +69,16 @@ class ParallelPyEnvironment(py_environment.PyEnvironment):
       raise ValueError('All environments must have the same action spec.')
     if any(env.time_step_spec() != self._time_step_spec for env in self._envs):
       raise ValueError('All environments must have the same time_step_spec.')
-    self._blocking = blocking
     self._flatten = flatten
 
   def start(self):
-    logging.info('Starting all processes.')
+    logging.info('Spawning all processes.')
     for env in self._envs:
-      env.start()
+      env.start(wait_to_start=self._blocking)
+    if not self._blocking:
+      logging.info('Waiting for all processes to start.')
+      for env in self._envs:
+          env.wait_start()
     logging.info('All processes started.')
 
   @property
@@ -189,14 +193,23 @@ class ProcessPyEnvironment(object):
     self._action_spec = None
     self._time_step_spec = None
 
-  def start(self):
-    """Start the process."""
+  def start(self, wait_to_start=True):
+    """Start the process.
+
+    Args:
+      wait_to_start: Whether the call should wait for an env initialization.
+    """
     self._conn, conn = multiprocessing.Pipe()
     self._process = multiprocessing.Process(
         target=self._worker,
         args=(conn, self._env_constructor, self._flatten))
     atexit.register(self.close)
     self._process.start()
+    if wait_to_start:
+      self.wait_start()
+
+  def wait_start(self):
+    """Wait for the started process to finish initialization"""
     result = self._conn.recv()
     if isinstance(result, Exception):
       self._conn.close()

--- a/tf_agents/environments/parallel_py_environment.py
+++ b/tf_agents/environments/parallel_py_environment.py
@@ -78,7 +78,7 @@ class ParallelPyEnvironment(py_environment.PyEnvironment):
     if not self._blocking:
       logging.info('Waiting for all processes to start.')
       for env in self._envs:
-          env.wait_start()
+        env.wait_start()
     logging.info('All processes started.')
 
   @property
@@ -209,7 +209,7 @@ class ProcessPyEnvironment(object):
       self.wait_start()
 
   def wait_start(self):
-    """Wait for the started process to finish initialization"""
+    """Wait for the started process to finish initialization."""
     result = self._conn.recv()
     if isinstance(result, Exception):
       self._conn.close()

--- a/tf_agents/environments/parallel_py_environment_test.py
+++ b/tf_agents/environments/parallel_py_environment_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import collections
 import functools
 import time
+import multiprocessing.dummy as dummy_multiprocessing
 
 import numpy as np
 import tensorflow as tf
@@ -35,13 +36,14 @@ from tf_agents.specs import array_spec
 class SlowStartingEnvironment(random_py_environment.RandomPyEnvironment):
   def __init__(self, *args, **kwargs):
     time_sleep = kwargs.pop('time_sleep', 1.0)
-     super().__init__(*args, **kwargs)
-￼     time.sleep(time_sleep)
-    super().__init__(*args, **kwargs)
     time.sleep(time_sleep)
+    super().__init__(*args, **kwargs)
 
 
 class ParallelPyEnvironmentTest(tf.test.TestCase):
+
+  def setUp(self):
+    parallel_py_environment.multiprocessing = dummy_multiprocessing
 
   def _set_default_specs(self):
     self.observation_spec = array_spec.ArraySpec((3, 3), np.float32)
@@ -100,14 +102,15 @@ class ParallelPyEnvironmentTest(tf.test.TestCase):
                                     self.observation_spec,
                                     self.action_spec, time_sleep=1.0)
     start_time = time.time()
-    self._make_parallel_py_environment(constructor=constructor,
-                                       num_envs=10,
-                                       blocking=False)
+    env = self._make_parallel_py_environment(constructor=constructor,
+                                             num_envs=10,
+                                             blocking=False)
     end_time = time.time()
     self.assertLessEqual(end_time - start_time, 5.0,
                          msg=('Expected all processes to start together, '
                               'got {} wait time').format(
                            end_time - start_time))
+    env.close()
 
   def test_blocking_start_processes_one_after_another(self):
     self._set_default_specs()
@@ -115,14 +118,15 @@ class ParallelPyEnvironmentTest(tf.test.TestCase):
                                     self.observation_spec,
                                     self.action_spec, time_sleep=1.0)
     start_time = time.time()
-    self._make_parallel_py_environment(constructor=constructor,
-                                       num_envs=10,
-                                       blocking=True)
+    env = self._make_parallel_py_environment(constructor=constructor,
+                                             num_envs=10,
+                                             blocking=True)
     end_time = time.time()
     self.assertGreater(end_time - start_time, 10,
                        msg=('Expected all processes to start one '
                             'after another, got {} wait time').format(
                          end_time - start_time))
+    env.close()
 
   def test_unstack_actions(self):
     num_envs = 2

--- a/tf_agents/environments/parallel_py_environment_test.py
+++ b/tf_agents/environments/parallel_py_environment_test.py
@@ -33,7 +33,10 @@ from tf_agents.specs import array_spec
 
 
 class SlowStartingEnvironment(random_py_environment.RandomPyEnvironment):
-  def __init__(self, *args, time_sleep=0.1, **kwargs):
+  def __init__(self, *args, **kwargs):
+    time_sleep = kwargs.pop('time_sleep', 1.0)
+     super().__init__(*args, **kwargs)
+￼     time.sleep(time_sleep)
     super().__init__(*args, **kwargs)
     time.sleep(time_sleep)
 
@@ -95,13 +98,13 @@ class ParallelPyEnvironmentTest(tf.test.TestCase):
     self._set_default_specs()
     constructor = functools.partial(SlowStartingEnvironment,
                                     self.observation_spec,
-                                    self.action_spec, time_sleep=0.1)
+                                    self.action_spec, time_sleep=1.0)
     start_time = time.time()
     self._make_parallel_py_environment(constructor=constructor,
                                        num_envs=10,
                                        blocking=False)
     end_time = time.time()
-    self.assertLessEqual(end_time - start_time, 0.5,
+    self.assertLessEqual(end_time - start_time, 5.0,
                          msg=('Expected all processes to start together, '
                               'got {} wait time').format(
                            end_time - start_time))
@@ -110,13 +113,13 @@ class ParallelPyEnvironmentTest(tf.test.TestCase):
     self._set_default_specs()
     constructor = functools.partial(SlowStartingEnvironment,
                                     self.observation_spec,
-                                    self.action_spec, time_sleep=0.05)
+                                    self.action_spec, time_sleep=1.0)
     start_time = time.time()
     self._make_parallel_py_environment(constructor=constructor,
                                        num_envs=10,
                                        blocking=True)
     end_time = time.time()
-    self.assertGreater(end_time - start_time, 0.3,
+    self.assertGreater(end_time - start_time, 10,
                        msg=('Expected all processes to start one '
                             'after another, got {} wait time').format(
                          end_time - start_time))

--- a/tf_agents/environments/parallel_py_environment_test.py
+++ b/tf_agents/environments/parallel_py_environment_test.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 
 import collections
 import functools
-import time
 import multiprocessing.dummy as dummy_multiprocessing
+import time
 
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
As is has already been discussed in #31, ParallelPyEnvironment takes too
much time to initialize for slow-starting environments due to sequential
`env.start()` calls.

This commit fixes #31 and adds tests for the fix.
I have also tested this implementation with a Unity environment. Initialization time dropped from 160 seconds to ~10 seconds for 16 environments.