### PR TITLE
Added missing Gym spaces

### DIFF
--- a/tf_agents/environments/gym_wrapper.py
+++ b/tf_agents/environments/gym_wrapper.py
@@ -67,7 +67,7 @@ def _spec_from_gym_space(space, dtype_map=None):
     return specs.BoundedArraySpec(
         shape=(), dtype=dtype, minimum=0, maximum=maximum)
   elif isinstance(space, gym.spaces.MultiDiscrete):
-    dtype = dtype_map.get(gym.spaces.MultiDiscrete, np.uint32)
+    dtype = dtype_map.get(gym.spaces.MultiDiscrete, np.int32)
     minimum = np.zeros_like(space.nvec, dtype=dtype)
     maximum = np.asarray(space.nvec - 1, dtype=dtype)
     return specs.BoundedArraySpec(

--- a/tf_agents/environments/gym_wrapper.py
+++ b/tf_agents/environments/gym_wrapper.py
@@ -66,6 +66,19 @@ def _spec_from_gym_space(space, dtype_map=None):
     dtype = dtype_map.get(gym.spaces.Discrete, np.int64)
     return specs.BoundedArraySpec(
         shape=(), dtype=dtype, minimum=0, maximum=maximum)
+  elif isinstance(space, gym.spaces.MultiDiscrete):
+    dtype = dtype_map.get(gym.spaces.MultiDiscrete, np.uint32)
+    minimum = np.zeros_like(space.nvec, dtype=dtype)
+    maximum = np.asarray(space.nvec - 1, dtype=dtype)
+    return specs.BoundedArraySpec(
+      shape=space.shape, dtype=dtype, minimum=minimum, maximum=maximum)
+  elif isinstance(space, gym.spaces.MultiBinary):
+    dtype = dtype_map.get(gym.spaces.MultiBinary, np.int8)
+    shape = (space.n, )
+    minimum = np.zeros(shape, dtype=dtype)
+    maximum = np.ones(shape, dtype=dtype)
+    return specs.BoundedArraySpec(
+      shape=shape, dtype=dtype, minimum=minimum, maximum=maximum)
   elif isinstance(space, gym.spaces.Box):
     # TODO(oars): change to use dtype in space once Gym is updated.
     dtype = dtype_map.get(gym.spaces.Box, np.float32)

--- a/tf_agents/environments/gym_wrapper_test.py
+++ b/tf_agents/environments/gym_wrapper_test.py
@@ -46,7 +46,7 @@ class GymWrapperSpecTest(absltest.TestCase):
     spec = gym_wrapper._spec_from_gym_space(multi_discrete_space)
 
     self.assertEqual((4,), spec.shape)
-    self.assertEqual(np.uint32, spec.dtype)
+    self.assertEqual(np.int32, spec.dtype)
     np.testing.assert_array_equal(
       np.array([0, 0, 0, 0], dtype=np.int),
       spec.minimum

--- a/tf_agents/environments/gym_wrapper_test.py
+++ b/tf_agents/environments/gym_wrapper_test.py
@@ -41,6 +41,36 @@ class GymWrapperSpecTest(absltest.TestCase):
     self.assertEqual(0, spec.minimum)
     self.assertEqual(2, spec.maximum)
 
+  def test_spec_from_gym_space_multi_discrete(self):
+    multi_discrete_space = gym.spaces.MultiDiscrete([1, 2, 3, 4])
+    spec = gym_wrapper._spec_from_gym_space(multi_discrete_space)
+
+    self.assertEqual((4,), spec.shape)
+    self.assertEqual(np.uint32, spec.dtype)
+    np.testing.assert_array_equal(
+      np.array([0, 0, 0, 0], dtype=np.int),
+      spec.minimum
+    )
+    np.testing.assert_array_equal(
+      np.array([0, 1, 2, 3], dtype=np.int),
+      spec.maximum
+    )
+
+  def test_spec_from_gym_space_multi_binary(self):
+    multi_binary_space = gym.spaces.MultiBinary(4)
+    spec = gym_wrapper._spec_from_gym_space(multi_binary_space)
+
+    self.assertEqual((4,), spec.shape)
+    self.assertEqual(np.int8, spec.dtype)
+    np.testing.assert_array_equal(
+      np.array([0, 0, 0, 0], dtype=np.int),
+      spec.minimum
+    )
+    np.testing.assert_array_equal(
+      np.array([1, 1, 1, 1], dtype=np.int),
+      spec.maximum
+    )
+
   def test_spec_from_gym_space_box_scalars(self):
     box_space = gym.spaces.Box(-1.0, 1.0, (3, 4))
     spec = gym_wrapper._spec_from_gym_space(box_space)


### PR DESCRIPTION
As discussed in #28, tf-agents lack MultiDiscrete space support.

This commit fixes #28 by adding the space as well as MultiBinary space.

Also added tests for the spaces.