### PR TITLE
Jupyter notebook: Drivers tutorial missing import fix

### DIFF
--- a/tf_agents/colabs/4_drivers_tutorial.ipynb
+++ b/tf_agents/colabs/4_drivers_tutorial.ipynb
@@ -39,6 +39,7 @@
       "outputs": [],
       "source": [
         "# Note: If you haven't installed tf-agents or gym yet, run:\n",
+        "!pip install tf-nightly\n",
         "!pip install tf-agents-nightly\n",
         "!pip install gym"
       ]


### PR DESCRIPTION
Nightly version of TF import was missing which caused error during notebook run.