### PR TITLE
Fix tf-nightly typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To install the nightly build version, run the following:
 pip install --user --upgrade tf-agents-nightly  # depends on tf-nightly
 ```
 
-If you clone the repository you will still need a `tf-nighly` installation. You can then run `pip install -e .[tests]` from the agents directory to get dependencies to run tests.
+If you clone the repository you will still need a `tf-nightly` installation. You can then run `pip install -e .[tests]` from the agents directory to get dependencies to run tests.
 
 <a id='Contributing'></a>
 ## Contributing


### PR DESCRIPTION
The PyPI package `tf-nightly` was written as `tf-nighly` in one occasion.