### PR TITLE
Fix a bug in the __eq__ method for BoundedArraySpec.

### DIFF
--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -350,8 +350,10 @@ class BoundedArraySpec(ArraySpec):
     if not isinstance(other, BoundedArraySpec):
       return False
     return (super(BoundedArraySpec, self).__eq__(other) and
-            np.array_equal(self.minimum, other.minimum) and
-            np.array_equal(self.maximum, other.maximum))
+            np.array_equal(np.broadcast_to(self.minimum, self.shape),
+                           np.broadcast_to(other.minimum, other.shape)) and
+            np.array_equal(np.broadcast_to(self.maximum, self.shape),
+                           np.broadcast_to(other.maximum, other.shape)))
 
   def check_array(self, array):
     """Return true if the given array conforms to the spec."""

--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -350,8 +350,8 @@ class BoundedArraySpec(ArraySpec):
     if not isinstance(other, BoundedArraySpec):
       return False
     return (super(BoundedArraySpec, self).__eq__(other) and
-            (self.minimum == other.minimum).all() and
-            (self.maximum == other.maximum).all())
+            np.array_equal(self.minimum, other.minimum) and
+            np.array_equal(self.maximum == other.maximum))
 
   def check_array(self, array):
     """Return true if the given array conforms to the spec."""

--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -351,7 +351,7 @@ class BoundedArraySpec(ArraySpec):
       return False
     return (super(BoundedArraySpec, self).__eq__(other) and
             np.array_equal(self.minimum, other.minimum) and
-            np.array_equal(self.maximum == other.maximum))
+            np.array_equal(self.maximum, other.maximum))
 
   def check_array(self, array):
     """Return true if the given array conforms to the spec."""

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -341,14 +341,14 @@ class BoundedArraySpecTest(parameterized.TestCase):
     self.assertNotEqual(spec_1, spec_2)
 
   def testNotEqualEmptyMinimum(self):
-      class MockBoundedArraySpec(array_spec.BoundedArraySpec):
-        @property
-        def minimum(self):
-          return np.array([])
+    class MockBoundedArraySpec(array_spec.BoundedArraySpec):
+      @property
+      def minimum(self):
+        return np.array([])
 
-      spec_1 = array_spec.BoundedArraySpec( (1,), np.int32, minimum=[-1.6], maximum=[1.0])
-      spec_2 = MockBoundedArraySpec( (1,), np.int32, minimum=[0.0], maximum=[1.0])
-      self.assertNotEqual(spec_1, spec_2)
+    spec_1 = array_spec.BoundedArraySpec( (1,), np.int32, minimum=[-1.6], maximum=[1.0])
+    spec_2 = MockBoundedArraySpec((1,), np.int32, minimum=[0.0], maximum=[1.0])
+    self.assertNotEqual(spec_1, spec_2)
 
   def testReuseSpec(self):
     spec_1 = array_spec.BoundedArraySpec(

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -340,6 +340,16 @@ class BoundedArraySpecTest(parameterized.TestCase):
         (1, 2), np.int32, minimum=[0.0, 0.0], maximum=[1.0, 1.0])
     self.assertNotEqual(spec_1, spec_2)
 
+  def testNotEqualEmptyMinimum(self):
+      class MockBoundedArraySpec(array_spec.BoundedArraySpec):
+        @property
+        def minimum(self):
+          return np.array([])
+
+      spec_1 = array_spec.BoundedArraySpec( (1,), np.int32, minimum=[-1.6], maximum=[1.0])
+      spec_2 = MockBoundedArraySpec( (1,), np.int32, minimum=[0.0], maximum=[1.0])
+      self.assertNotEqual(spec_1, spec_2)
+
   def testReuseSpec(self):
     spec_1 = array_spec.BoundedArraySpec(
         (1, 2), np.int32, minimum=0.0, maximum=1.0)


### PR DESCRIPTION
When one.minimum property is an empty array
(for example in a child class)
and other.minimum contains a single element
the equality used to be true.
(see for example https://stackoverflow.com/a/10580782/4282745).