### PR TITLE
Dynamic array spec

### DIFF
--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -69,7 +69,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     time_step = random_env.step(action=np.ones((1,)))
     self.assertLess(time_step.observation.shape[0], 10)
     self.assertGreaterEqual(time_step.observation.shape[0], 0)
-    self.assertEqual(1, time_step.observation.shape[1])
+    self.assertEqual(time_step.observation.shape[1], 1)
 
   def testStepWithStaticObservationShape(self):
     obs_spec = array_spec.BoundedArraySpec((2, 1,), np.int32)
@@ -83,7 +83,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     current_time_step = random_env.current_time_step()
     tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
     self.assertEqual(time_step.observation.shape[0], 2)
-    self.assertEqual(1, time_step.observation.shape[1])
+    self.assertEqual(time_step.observation.shape[1], 1)
 
 
 if __name__ == '__main__':

--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -59,17 +59,19 @@ class PyEnvironmentTest(tf.test.TestCase):
         observation_spec=obs_spec, action_spec=action_spec)
 
     random_env.reset()
-    time_step = random_env.step(action=np.ones((1,)))
-    current_time_step = random_env.current_time_step()
-    tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
-    self.assertLess(time_step.observation.shape[0], 10)
-    self.assertGreaterEqual(time_step.observation.shape[0], 0)
-    self.assertEqual(1, time_step.observation.shape[1])
 
-    time_step = random_env.step(action=np.ones((1,)))
-    self.assertLess(time_step.observation.shape[0], 10)
-    self.assertGreaterEqual(time_step.observation.shape[0], 0)
-    self.assertEqual(time_step.observation.shape[1], 1)
+    def assert_observation_first_dim_is(dim):
+        time_step = random_env.step(action=np.ones((1,)))
+        current_time_step = random_env.current_time_step()
+        tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
+        self.assertEqual(dim, time_step.observation.shape[0])
+        self.assertEqual(1, time_step.observation.shape[1])
+
+    assert_observation_first_dim_is(1)
+    assert_observation_first_dim_is(0)
+    assert_observation_first_dim_is(1)
+    assert_observation_first_dim_is(2)
+    assert_observation_first_dim_is(3)
 
   def testStepWithStaticObservationShape(self):
     obs_spec = array_spec.BoundedArraySpec((2, 1,), np.int32)

--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -51,6 +51,41 @@ class PyEnvironmentTest(tf.test.TestCase):
     current_time_step = random_env.current_time_step()
     tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
 
+  def testStepSavesCurrentTimeStepDynamic(self):
+    obs_spec = array_spec.BoundedArraySpec((None, 1,), np.int32)
+    action_spec = array_spec.BoundedArraySpec((1,), np.int32)
+
+    random_env = random_py_environment.DynamicRandomPyEnvironment(
+        observation_spec=obs_spec, action_spec=action_spec)
+
+    random_env.reset()
+    time_step = random_env.step(action=np.ones((1,)))
+    current_time_step = random_env.current_time_step()
+    tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
+    self.assertLess(time_step.observation.shape[0], 10)
+    self.assertGreaterEqual(time_step.observation.shape[0], 0)
+    self.assertEqual(1, time_step.observation.shape[1])
+
+    time_step = random_env.step(action=np.ones((1,)))
+    self.assertLess(time_step.observation.shape[0], 10)
+    self.assertGreaterEqual(time_step.observation.shape[0], 0)
+    self.assertEqual(1, time_step.observation.shape[1])
+
+  def testStepSavesCurrentTimeStepStatic(self):
+    obs_spec = array_spec.BoundedArraySpec((2, 1,), np.int32)
+    action_spec = array_spec.BoundedArraySpec((1,), np.int32)
+
+    random_env = random_py_environment.DynamicRandomPyEnvironment(
+        observation_spec=obs_spec, action_spec=action_spec)
+
+    random_env.reset()
+    time_step = random_env.step(action=np.ones((1,)))
+    current_time_step = random_env.current_time_step()
+    tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
+    self.assertLess(time_step.observation.shape[0], 10)
+    self.assertGreaterEqual(time_step.observation.shape[0], 0)
+    self.assertEqual(1, time_step.observation.shape[1])
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -51,7 +51,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     current_time_step = random_env.current_time_step()
     tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
 
-  def testStepSavesCurrentTimeStepDynamic(self):
+  def testStepWithDynamicObservationShape(self):
     obs_spec = array_spec.BoundedArraySpec((None, 1,), np.int32)
     action_spec = array_spec.BoundedArraySpec((1,), np.int32)
 
@@ -71,7 +71,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     self.assertGreaterEqual(time_step.observation.shape[0], 0)
     self.assertEqual(1, time_step.observation.shape[1])
 
-  def testStepSavesCurrentTimeStepStatic(self):
+  def testStepWithStaticObservationShape(self):
     obs_spec = array_spec.BoundedArraySpec((2, 1,), np.int32)
     action_spec = array_spec.BoundedArraySpec((1,), np.int32)
 
@@ -82,8 +82,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     time_step = random_env.step(action=np.ones((1,)))
     current_time_step = random_env.current_time_step()
     tf.nest.map_structure(self.assertAllEqual, time_step, current_time_step)
-    self.assertLess(time_step.observation.shape[0], 10)
-    self.assertGreaterEqual(time_step.observation.shape[0], 0)
+    self.assertEqual(time_step.observation.shape[0], 2)
     self.assertEqual(1, time_step.observation.shape[1])
 
 

--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -26,6 +26,20 @@ from tf_agents.environments import random_py_environment
 from tf_agents.specs import array_spec
 
 
+class DynamicRandomPyEnvironment(random_py_environment.RandomPyEnvironment):
+  """Example of environment with a random observation dimension using a dynamic shape."""
+
+  def _get_observation(self):
+    # Observation has a dynamic shape sampled uniformly between 0 and 4.
+    num_dynamic_dims = len([d for d in self._observation_spec.shape if d is None])
+    observation_spec = self._observation_spec
+    if num_dynamic_dims > 0:
+        dynamic_dims = self._rng.randint(low=-1, high=5, size=num_dynamic_dims)
+        observation_spec = array_spec.set_dynamic_dims_nest(observation_spec, dynamic_dims)
+    batch_size = (self._batch_size,) if self._batch_size else ()
+    return array_spec.sample_spec_nest(observation_spec, self._rng, batch_size)
+
+
 class PyEnvironmentTest(tf.test.TestCase):
 
   def testResetSavesCurrentTimeStep(self):
@@ -55,7 +69,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     obs_spec = array_spec.BoundedArraySpec((None, 1,), np.int32)
     action_spec = array_spec.BoundedArraySpec((1,), np.int32)
 
-    random_env = random_py_environment.DynamicRandomPyEnvironment(
+    random_env = DynamicRandomPyEnvironment(
         observation_spec=obs_spec, action_spec=action_spec)
 
     random_env.reset()
@@ -77,7 +91,7 @@ class PyEnvironmentTest(tf.test.TestCase):
     obs_spec = array_spec.BoundedArraySpec((2, 1,), np.int32)
     action_spec = array_spec.BoundedArraySpec((1,), np.int32)
 
-    random_env = random_py_environment.DynamicRandomPyEnvironment(
+    random_env = DynamicRandomPyEnvironment(
         observation_spec=obs_spec, action_spec=action_spec)
 
     random_env.reset()

--- a/tf_agents/environments/random_py_environment.py
+++ b/tf_agents/environments/random_py_environment.py
@@ -169,17 +169,3 @@ class RandomPyEnvironment(py_environment.PyEnvironment):
           format(mode))
 
     return self._rng.randint(0, 256, size=self._render_size, dtype=np.uint8)
-
-
-class DynamicRandomPyEnvironment(RandomPyEnvironment):
-
-  def _get_observation(self):
-    # Observation has a dynamic shape sampled uniformly between 0 and 4.
-    num_dynamic_dims = len([d for d in self._observation_spec.shape if d is None])
-    observation_spec = self._observation_spec
-    if num_dynamic_dims > 0:
-        dynamic_dims = self._rng.randint(low=-1, high=5, size=num_dynamic_dims)
-        observation_spec = array_spec.set_dynamic_dims_nest(observation_spec, dynamic_dims)
-    batch_size = (self._batch_size,) if self._batch_size else ()
-    return array_spec.sample_spec_nest(observation_spec, self._rng, batch_size)
-

--- a/tf_agents/environments/random_py_environment.py
+++ b/tf_agents/environments/random_py_environment.py
@@ -174,11 +174,11 @@ class RandomPyEnvironment(py_environment.PyEnvironment):
 class DynamicRandomPyEnvironment(RandomPyEnvironment):
 
   def _get_observation(self):
-    # Observation has a dynamic shape sampled uniformly between 0 and 9.
+    # Observation has a dynamic shape sampled uniformly between 0 and 4.
     num_dynamic_dims = len([d for d in self._observation_spec.shape if d is None])
     observation_spec = self._observation_spec
     if num_dynamic_dims > 0:
-        dynamic_dims = np.random.randint(10, size=num_dynamic_dims)
+        dynamic_dims = self._rng.randint(low=-1, high=5, size=num_dynamic_dims)
         observation_spec = array_spec.set_dynamic_dims_nest(observation_spec, dynamic_dims)
     batch_size = (self._batch_size,) if self._batch_size else ()
     return array_spec.sample_spec_nest(observation_spec, self._rng, batch_size)

--- a/tf_agents/environments/random_py_environment.py
+++ b/tf_agents/environments/random_py_environment.py
@@ -169,3 +169,17 @@ class RandomPyEnvironment(py_environment.PyEnvironment):
           format(mode))
 
     return self._rng.randint(0, 256, size=self._render_size, dtype=np.uint8)
+
+
+class DynamicRandomPyEnvironment(RandomPyEnvironment):
+
+  def _get_observation(self):
+    # Observation has a dynamic shape sampled uniformly between 0 and 9.
+    num_dynamic_dims = len([d for d in self._observation_spec.shape if d is None])
+    observation_spec = self._observation_spec
+    if num_dynamic_dims > 0:
+        dynamic_dims = np.random.randint(10, size=num_dynamic_dims)
+        observation_spec = array_spec.set_dynamic_dims_nest(observation_spec, dynamic_dims)
+    batch_size = (self._batch_size,) if self._batch_size else ()
+    return array_spec.sample_spec_nest(observation_spec, self._rng, batch_size)
+

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -540,8 +540,9 @@ class BoundedArraySpecTest(parameterized.TestCase):
     a = np.zeros([1, 2, 3], dtype=np.int32)
     self.assertTrue(spec.check_array(a))
 
-    spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 2, 3]))
-    self.assertTrue(spec.check_array(a))
+    with self.assertRaises(ValueError):
+      # Minimum should be broadcastable from the static dimensions to full shape with dynamic dimensions set to 1.
+      array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 2, 3]))
 
   def testConvertToTensor(self):
     spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=0, maximum=10)

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -519,10 +519,12 @@ class BoundedArraySpecTest(parameterized.TestCase):
   def testDynamicShapeFullArrayMin(self):
     spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 3]))
     self.assertEqual((1, None, 3), spec.shape)
+    spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 1, 3]))
+    self.assertEqual((1, None, 3), spec.shape)
 
   def testDynamicShapeArrayMinWrongShape(self):
     with self.assertRaises(ValueError):
-      # When using dynamic shape, minimum should be 0 or broadcastable among known dimensions.
+      # When using dynamic shape, minimum should be scalar or broadcastable to full shape with dynamic dimensions set to 1.
       array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 2, 3]))
 
   def testEqualDynamicShape(self):
@@ -540,9 +542,8 @@ class BoundedArraySpecTest(parameterized.TestCase):
     a = np.zeros([1, 2, 3], dtype=np.int32)
     self.assertTrue(spec.check_array(a))
 
-    with self.assertRaises(ValueError):
-      # Minimum should be broadcastable from the static dimensions to full shape with dynamic dimensions set to 1.
-      array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 2, 3]))
+    spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=np.zeros([1, 1, 3]))
+    self.assertTrue(spec.check_array(a))
 
   def testConvertToTensor(self):
     spec = array_spec.BoundedArraySpec([1, None, 3], np.int32, minimum=0, maximum=10)

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -569,6 +569,7 @@ class ArraySpecTypeTest(parameterized.TestCase):
     self.assertIs(
         tensor_spec.is_discrete(spec) ^ tensor_spec.is_continuous(spec), True)
 
+
 class MethodsTest(tf.test.TestCase):
   def test_set_dynamic_dims_nest(self):
     dynamic_spec = array_spec.ArraySpec([None, 1], dtype=np.int32)

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -569,6 +569,17 @@ class ArraySpecTypeTest(parameterized.TestCase):
     self.assertIs(
         tensor_spec.is_discrete(spec) ^ tensor_spec.is_continuous(spec), True)
 
+class MethodsTest(tf.test.TestCase):
+  def test_set_dynamic_dims_nest(self):
+    dynamic_spec = array_spec.ArraySpec([None, 1], dtype=np.int32)
+    spec = array_spec.set_dynamic_dims_nest(dynamic_spec, [2])
+    self.assertTrue((2, 1), spec.shape)
+
+  def test_set_dynamic_dims_nest_error(self):
+    dynamic_spec = array_spec.ArraySpec([None, 1], dtype=np.int32)
+    with self.assertRaises(ValueError):
+      array_spec.set_dynamic_dims_nest(dynamic_spec, [2, 3])
+
 
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
Make (Bounded)ArraySpec allow for dynamic shape following the same convention than in tensorflow: any None dimension represents a dynamic dimension. This is to allow for the cases where observations can have a dynamic dimension: for example if the observation can be empty or a concatenation of several atomic observations.

Check that the conversion to tensor works fine.

Implement an example of RandomPyEnvironment where the observation can have dynamic dimensions drown between 0 and 4.

Add a helper function to set the unknown dimensions of a dynamic shape to given values.