### PR TITLE
Fix a bug where batch* properties were not forwarded to the wrapped env.

### DIFF
--- a/tf_agents/environments/wrappers.py
+++ b/tf_agents/environments/wrappers.py
@@ -48,6 +48,14 @@ class PyEnvironmentBaseWrapper(py_environment.PyEnvironment):
     """Forward all other calls to the base environment."""
     return getattr(self._env, name)
 
+  @property
+  def batch_size(self):
+    return self._env.batch_size
+
+  @property
+  def batched(self):
+    return self._env.batched
+
   def _reset(self):
     return self._env.reset()
 

--- a/tf_agents/environments/wrappers.py
+++ b/tf_agents/environments/wrappers.py
@@ -47,14 +47,14 @@ class PyEnvironmentBaseWrapper(py_environment.PyEnvironment):
   def __getattr__(self, name):
     """Forward all other calls to the base environment."""
     return getattr(self._env, name)
+  
+  @property
+  def batched(self):
+    return getattr(self._env, "batched", super().batched)
 
   @property
   def batch_size(self):
-    return self._env.batch_size
-
-  @property
-  def batched(self):
-    return self._env.batched
+    return getattr(self._env, "batch_size", super().batch_size)
 
   def _reset(self):
     return self._env.reset()

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -51,6 +51,12 @@ class PyEnvironmentBaseWrapperTest(parameterized.TestCase):
     env = wrappers.PyEnvironmentBaseWrapper(nested_env)
     self.assertEqual(env.batched, nested_env.batched)
     self.assertEqual(nested_env.batch_size, env.batch_size)
+    
+  def test_default_batch_properties(self):
+    cartpole_env = gym.spec('CartPole-v1').make()
+    env = gym_wrapper.GymWrapper(cartpole_env)
+    self.assertFalse(env.batched)
+    self.assertEqual(env.batch_size, None)
 
 
 class TimeLimitWrapperTest(absltest.TestCase):

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -36,6 +36,23 @@ from tf_agents.environments import wrappers
 from tf_agents.specs import array_spec
 
 
+class PyEnvironmentBaseWrapperTest(parameterized.TestCase):
+
+  @parameterized.named_parameters({"testcase_name": "scalar", "batch_size": None},
+                                  {"testcase_name": "batched", "batch_size": 2}, )
+  def test_batch_properties(self, batch_size):
+    obs_spec = array_spec.BoundedArraySpec((2, 3), np.int32, -10, 10)
+    action_spec = array_spec.BoundedArraySpec((1,), np.int32, -10, 10)
+    nested_env = random_py_environment.RandomPyEnvironment(
+      obs_spec,
+      action_spec,
+      reward_fn=lambda *_: np.array([1.0]),
+      batch_size=batch_size)
+    env = wrappers.PyEnvironmentBaseWrapper(nested_env)
+    self.assertEqual(env.batched, nested_env.batched)
+    self.assertEqual(nested_env.batch_size, env.batch_size)
+
+
 class TimeLimitWrapperTest(absltest.TestCase):
 
   def test_limit_duration_wrapped_env_forwards_calls(self):


### PR DESCRIPTION
Fix bug #69 where batch* properties were not forwarded to the wrapped env by `PyEnvironmentBaseWrapper` and implements unit tests.