### PR TITLE
Add __version__, fixes #114

### DIFF
--- a/tf_agents/__init__.py
+++ b/tf_agents/__init__.py
@@ -64,6 +64,7 @@ def _ensure_tf_install():  # pylint: disable=g-statement-before-imports
 
 _ensure_tf_install()
 
+from tf_agents.version import __version__
 
 # Cleanup symbols to avoid polluting namespace.
 import sys as _sys


### PR DESCRIPTION
Just imports `__version__` from `tf_agents.version` for PEP 396.