### PR TITLE
Add a new Atari wrapper to fire on reset

### DIFF
--- a/tf_agents/environments/atari_wrappers.py
+++ b/tf_agents/environments/atari_wrappers.py
@@ -94,3 +94,19 @@ class AtariTimeLimit(wrappers.PyEnvironmentBaseWrapper):
   @property
   def game_over(self):
     return self._num_steps >= self._duration or self.gym.game_over
+
+
+class FireOnReset(gym.Wrapper):
+  """Start every episode with action 1 (FIRE) + another action (2).
+
+  This is required by some environments (e.g., Breakout) to actually start the
+  game.
+  """
+
+  def reset(self):
+    observation = self.env.reset()
+    action_meanings = self.env.unwrapped.get_action_meanings()
+    if action_meanings[1] == 'FIRE' and len(action_meanings) >= 3:
+        self.env.step(1)
+        observation, _, _, _ = self.env.step(2)
+    return observation

--- a/tf_agents/environments/atari_wrappers.py
+++ b/tf_agents/environments/atari_wrappers.py
@@ -99,12 +99,14 @@ class AtariTimeLimit(wrappers.PyEnvironmentBaseWrapper):
 class FireOnReset(gym.Wrapper):
   """Start every episode with action 1 (FIRE) + another action (2).
 
-  This is required by some environments (e.g., Breakout) to actually start the
-  game.
+  In some environments (e.g., BeamRider, Breakout, Tennis) nothing
+  happens until the player presses the FIRE button.
   """
 
   def reset(self):
     observation = self.env.reset()
+    # The following code is from https://github.com/openai/gym/...
+    # ...blob/master/gym/wrappers/atari_preprocessing.py
     action_meanings = self.env.unwrapped.get_action_meanings()
     if action_meanings[1] == 'FIRE' and len(action_meanings) >= 3:
         self.env.step(1)

--- a/tf_agents/environments/suite_atari.py
+++ b/tf_agents/environments/suite_atari.py
@@ -29,13 +29,14 @@ import gin.tf
 
 
 # Typical Atari 2600 Gym environment with some basic preprocessing.
-DEFAULT_ATARI_GYM_WRAPPERS = (atari_preprocessing.AtariPreprocessing,)
+DEFAULT_ATARI_GYM_WRAPPERS = (atari_preprocessing.AtariPreprocessing,
+                              atari_wrappers.FireOnReset)
 # The following is just AtariPreprocessing with frame stacking. Performance wise
 # it's much better to have stacking implemented as part of replay-buffer/agent.
 # As soon as this functionality in TF-Agents is ready and verified, this set of
 # wrappers will be removed.
-DEFAULT_ATARI_GYM_WRAPPERS_WITH_STACKING = (
-    atari_preprocessing.AtariPreprocessing, atari_wrappers.FrameStack4)
+DEFAULT_ATARI_GYM_WRAPPERS_WITH_STACKING = DEFAULT_ATARI_GYM_WRAPPERS + (
+    atari_wrappers.FrameStack4,)
 
 
 @gin.configurable

--- a/tf_agents/environments/suite_atari.py
+++ b/tf_agents/environments/suite_atari.py
@@ -29,8 +29,7 @@ import gin.tf
 
 
 # Typical Atari 2600 Gym environment with some basic preprocessing.
-DEFAULT_ATARI_GYM_WRAPPERS = (atari_preprocessing.AtariPreprocessing,
-                              atari_wrappers.FireOnReset)
+DEFAULT_ATARI_GYM_WRAPPERS = (atari_preprocessing.AtariPreprocessing,)
 # The following is just AtariPreprocessing with frame stacking. Performance wise
 # it's much better to have stacking implemented as part of replay-buffer/agent.
 # As soon as this functionality in TF-Agents is ready and verified, this set of


### PR DESCRIPTION
Inspired from [this code](https://github.com/openai/gym/blob/master/gym/wrappers/atari_preprocessing.py#L104).
Some Atari games do not start until you press fire.