### PR TITLE
Make the use of tf_functions optional

### DIFF
--- a/tf_agents/eval/metric_utils.py
+++ b/tf_agents/eval/metric_utils.py
@@ -123,7 +123,8 @@ def eager_compute(metrics,
                   num_episodes=1,
                   train_step=None,
                   summary_writer=None,
-                  summary_prefix=''):
+                  summary_prefix='',
+                  use_tf_functions=True):
   """Compute metrics using `policy` on the `environment`.
 
   *NOTE*: Because placeholders are not compatible with Eager mode we can not use
@@ -153,7 +154,11 @@ def eager_compute(metrics,
       policy,
       observers=metrics,
       num_episodes=num_episodes)
-  common.function(driver.run)(time_step, policy_state)
+  
+  if use_tf_functions:
+    common.function(driver.run)(time_step, policy_state)
+  else:
+    driver.run(time_step, policy_state)
 
   results = [(metric.name, metric.result()) for metric in metrics]
   # TODO(b/120301678) remove the summaries and merge with compute


### PR DESCRIPTION
I had a bug where using a slightly customized version of the code from `agents/ppo/examples/v2/train_eval.py` resulted in extreme slow-down whenever the script entered `metric_utils.eager_compute` in line 205.

Since then I identified the use of `common.function(driver.run)` in line 156 of `eval/metric_utils.py` as the reason for this. Removing common.function fixed the issue, which is why I would suggest to make the usage optional until the cause of slow-down is identified and fixed.