### PR TITLE
fix a bug when frame_skip==1

### DIFF
--- a/tf_agents/environments/atari_preprocessing.py
+++ b/tf_agents/environments/atari_preprocessing.py
@@ -187,7 +187,11 @@ class AtariPreprocessing(object):
       # We max-pool over the last two frames, in grayscale.
       elif time_step >= self.frame_skip - 2:
         t = time_step - (self.frame_skip - 2)
+        # when frame_skip==1, self.screen_buffer[1] will be filled!
         self._fetch_grayscale_observation(self.screen_buffer[t])
+
+    if self.frame_skip == 1:
+      self.screen_buffer[0] = self.screen_buffer[1]
 
     # Pool the last two observations.
     observation = self._pool_and_resize()


### PR DESCRIPTION
When self.frame_skip==1, the original code will fill in buffer[1]. However, inside self._pool_and_resize(), buffer[0] is always used. So the entire episode will always output the first frame as the observations at different time steps. I add a special handling for the case of self.frame_skip==1 to fix this issue.