### PR TITLE
Wrap envs with multidiscrete action space into discrete action space

### DIFF
--- a/tf_agents/environments/wrappers.py
+++ b/tf_agents/environments/wrappers.py
@@ -719,3 +719,30 @@ class HistoryWrapper(PyEnvironmentBaseWrapper):
 
     time_step = self._env.step(action)
     return self._add_history(time_step, action)
+
+@gin.configurable
+class MultiDiscreteToDiscreteWrapper(PyEnvironmentBaseWrapper):
+  """Converts an environment with Multidiscrete action space into a Discrete one."""
+
+  def __init__(self, env, times):
+    """Creates an environment wrapper that converts the action space.
+
+    Args:
+      env: Environment to wrap.
+
+    Raises:
+      ValueError: If the environment does not have multidiscrete action space.
+    """
+    super(MultiDiscreteToDiscrete, self).__init__(env)
+
+  def _multidiscrete_to_discrete(self, multidiscrete_action):
+    # TODO Implement
+    discrete_action = multidiscrete_action
+    return discrete_action
+
+  def _step(self, action):
+    return self._env_step(self._multidiscrete_to_discrete(action))
+
+  def action_spec(self):
+    # TODO Fix action spec
+    return self._env.action_spec()

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -923,14 +923,14 @@ class StubMultiDiscreteEnv(py_environment.PyEnvironment):
     return ts.restart(self._position.copy())
 
   def observation_spec(self):
-    return array_spec.ArraySpec((2, ), np.int32)
+    return specs.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
 
   def action_spec(self):
-    return array_spec.ArraySpec((2, ), np.int32)
+    return specs.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
 
   def _step(self, action):
     self._position += action
-    if self._position[0] + self._position[1] < 4:
+    if self._position[0] + self._position[1] < 2:
       return ts.transition(self._position.copy(), 1)
     return ts.termination(self._position.copy(), 1)
 

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -916,6 +916,7 @@ class HistoryWrapperTest(absltest.TestCase):
 
 class StubMultiDiscreteEnv(py_environment.PyEnvironment):
   def __init__(self):
+    super(StubMultiDiscreteEnv, self).__init__()
     self._position = np.array([0, 0], dtype=np.int32)
 
   def _reset(self):
@@ -923,10 +924,10 @@ class StubMultiDiscreteEnv(py_environment.PyEnvironment):
     return ts.restart(self._position.copy())
 
   def observation_spec(self):
-    return specs.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
+    return array_spec.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
 
   def action_spec(self):
-    return specs.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
+    return array_spec.BoundedArraySpec(shape=(2, 2), dtype=np.int32, minimum=0, maximum=1)
 
   def _step(self, action):
     self._position += action
@@ -937,13 +938,30 @@ class StubMultiDiscreteEnv(py_environment.PyEnvironment):
 
 class MultiDiscreteToDiscreteWrapperTest(absltest.TestCase):
 
-  def test_action_spec_changed(self):
-    # TODO Write unit tests
-    pass
+  def test_new_action_spec_shape(self):
+    env = StubMultiDiscreteEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(env)
+    self.assertEqual((4, ), wrapped_env.action_spec().shape)
 
-  def test_action_changed(self):
-    # TODO Write unit tests
-    pass
+  def test_new_and_old_actions_have_one_to_one_correspondence(self):
+    env = StubMultiDiscreteEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(StubMultiDiscreteEnv())
+
+    ts = env.step((0, 0))
+    wrapped_ts = wrapped_env.step(0)
+    self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
+
+    ts = env.step((0, 1))
+    wrapped_ts = wrapped_env.step(1)
+    self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
+
+    ts = env.step((1, 0))
+    wrapped_ts = wrapped_env.step(2)
+    self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
+
+    ts = env.step((1, 1))
+    wrapped_ts = wrapped_env.step(3)
+    self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
 
 
 if __name__ == '__main__':

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -914,9 +914,9 @@ class HistoryWrapperTest(absltest.TestCase):
     self.assertEqual([5, 6, 7], time_step.observation['action'].tolist())
 
 
-class StubMultiDiscreteEnv(py_environment.PyEnvironment):
+class CustomMultiDiscretePyEnv(py_environment.PyEnvironment):
   def __init__(self):
-    super(StubMultiDiscreteEnv, self).__init__()
+    super(CustomMultiDiscretePyEnv, self).__init__()
     self._position = np.array([0, 0], dtype=np.int32)
 
   def _reset(self):
@@ -939,26 +939,31 @@ class StubMultiDiscreteEnv(py_environment.PyEnvironment):
 class MultiDiscreteToDiscreteWrapperTest(absltest.TestCase):
 
   def test_new_action_spec_shape(self):
-    env = StubMultiDiscreteEnv()
+    env = CustomMultiDiscretePyEnv()
     wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(env)
     self.assertEqual((4, ), wrapped_env.action_spec().shape)
 
   def test_new_and_old_actions_have_one_to_one_correspondence(self):
-    env = StubMultiDiscreteEnv()
-    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(StubMultiDiscreteEnv())
-
+    env = CustomMultiDiscretePyEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(CustomMultiDiscretePyEnv())
     ts = env.step((0, 0))
     wrapped_ts = wrapped_env.step(0)
     self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
 
+    env = CustomMultiDiscretePyEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(CustomMultiDiscretePyEnv())
     ts = env.step((0, 1))
     wrapped_ts = wrapped_env.step(1)
     self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
 
+    env = CustomMultiDiscretePyEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(CustomMultiDiscretePyEnv())
     ts = env.step((1, 0))
     wrapped_ts = wrapped_env.step(2)
     self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())
 
+    env = CustomMultiDiscretePyEnv()
+    wrapped_env = wrappers.MultiDiscreteToDiscreteWrapper(CustomMultiDiscretePyEnv())
     ts = env.step((1, 1))
     wrapped_ts = wrapped_env.step(3)
     self.assertEqual(ts.observation.tolist(), wrapped_ts.observation.tolist())

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -914,5 +914,37 @@ class HistoryWrapperTest(absltest.TestCase):
     self.assertEqual([5, 6, 7], time_step.observation['action'].tolist())
 
 
+class StubMultiDiscreteEnv(py_environment.PyEnvironment):
+  def __init__(self):
+    self._position = np.array([0, 0], dtype=np.int32)
+
+  def _reset(self):
+    self._position = np.array([0, 0], dtype=np.int32)
+    return ts.restart(self._position.copy())
+
+  def observation_spec(self):
+    return array_spec.ArraySpec((2, ), np.int32)
+
+  def action_spec(self):
+    return array_spec.ArraySpec((2, ), np.int32)
+
+  def _step(self, action):
+    self._position += action
+    if self._position[0] + self._position[1] < 4:
+      return ts.transition(self._position.copy(), 1)
+    return ts.termination(self._position.copy(), 1)
+
+
+class MultiDiscreteToDiscreteWrapperTest(absltest.TestCase):
+
+  def test_action_spec_changed(self):
+    # TODO Write unit tests
+    pass
+
+  def test_action_changed(self):
+    # TODO Write unit tests
+    pass
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Some Gym environments have multidiscrete action spaces. (ex. [Unity's Obstacle Tower environment](https://github.com/Unity-Technologies/obstacle-tower-env)) This PR implements `MultiDiscreteToDiscreteWrapper`, an environment wrapper that wraps such environments to make them into an environment with discrete action spaces.

Resolves Issue #97 