### PR TITLE
Allow passing gym_kwargs in suite_gym.load()

### DIFF
--- a/tf_agents/environments/suite_gym.py
+++ b/tf_agents/environments/suite_gym.py
@@ -35,7 +35,8 @@ def load(environment_name,
          max_episode_steps=None,
          gym_env_wrappers=(),
          env_wrappers=(),
-         spec_dtype_map=None):
+         spec_dtype_map=None,
+         gym_kwargs=None):
   """Loads the selected environment and wraps it with the specified wrappers.
 
   Note that by default a TimeLimit wrapper is used to limit episode lengths
@@ -56,12 +57,14 @@ def load(environment_name,
       mapping through Gin is to define a gin-configurable function that returns
       desired mapping and call it in your Gin congif file, for example:
       `suite_gym.load.spec_dtype_map = @get_custom_mapping()`.
+    gym_kwargs: The kwargs to pass to the Gym environment class.
 
   Returns:
     A PyEnvironment instance.
   """
+  gym_kwargs = gym_kwargs if gym_kwargs else {}
   gym_spec = gym.spec(environment_name)
-  gym_env = gym_spec.make()
+  gym_env = gym_spec.make(**gym_kwargs)
 
   if max_episode_steps is None and gym_spec.max_episode_steps is not None:
     max_episode_steps = gym_spec.max_episode_steps

--- a/tf_agents/environments/suite_gym_test.py
+++ b/tf_agents/environments/suite_gym_test.py
@@ -67,6 +67,12 @@ class SuiteGymTest(absltest.TestCase):
     self.assertIsInstance(env, py_environment.PyEnvironment)
     self.assertIsInstance(env, wrappers.TimeLimit)
 
+  def test_gym_kwargs_argument(self):
+    env = suite_gym.load('FrozenLake-v0', gym_kwargs={'map_name': '4x4'})
+    self.assertTupleEqual(env.unwrapped.desc.shape, (4, 4))
+
+    env = suite_gym.load('FrozenLake-v0', gym_kwargs={'map_name': '8x8'})
+    self.assertTupleEqual(env.unwrapped.desc.shape, (8, 8))
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Some environments can be customized through additional `kwargs`. This PR allows users to pass a dictionary `gym_kwargs` to `suite_gym.load()` for such environments.

The unit test uses `FrozenLake-v0` environment and verifies that the user can set the size of the map  through `gym_kwargs`.

Mentioned in issues #99 and #137 