### PR TITLE
Stabler Tanh bijector

### DIFF
--- a/tf_agents/distributions/tanh_bijector_stable.py
+++ b/tf_agents/distributions/tanh_bijector_stable.py
@@ -53,6 +53,11 @@ class Tanh(bijector.Bijector):
     return tf.nn.tanh(x)
 
   def _inverse(self, y):
+    # 0.99999997 is the maximum value such that atanh(x) is valid for both
+    # tf.float32 and tf.float64
+    y = tf.where(tf.less_equal(tf.abs(y), 1.),
+                 tf.clip_by_value(y, -0.99999997, 0.99999997),
+                 y)
     return tf.atanh(y)
 
   def _forward_log_det_jacobian(self, x):


### PR DESCRIPTION
Because of limited floating point precision, tanh(9.01) will get 1.0, which cannot be inverted. A input value of 9.01 is not the uncommon. Consider a Gaussian distribution with mean=1.0 and std=2. You can get a sample larger than 9.01 or smaller than -9.01 with probability 6.2e-5. So we change Tanh._inverse() to make it more stabler.