### PR TITLE
Remove duplicate loss functions defined in dqn_agent

### DIFF
--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -66,18 +66,6 @@ class DqnLossInfo(collections.namedtuple('DqnLossInfo',
   pass
 
 
-# TODO(damienv): Definition of those element wise losses should not belong to
-# this file. Move them to utils/common or utils/losses.
-def element_wise_squared_loss(x, y):
-  return tf.compat.v1.losses.mean_squared_error(
-      x, y, reduction=tf.compat.v1.losses.Reduction.NONE)
-
-
-def element_wise_huber_loss(x, y):
-  return tf.compat.v1.losses.huber_loss(
-      x, y, reduction=tf.compat.v1.losses.Reduction.NONE)
-
-
 def compute_td_targets(next_q_values, rewards, discounts):
   return tf.stop_gradient(rewards + discounts * next_q_values)
 
@@ -192,7 +180,7 @@ class DqnAgent(tf_agent.TFAgent):
     self._n_step_update = n_step_update
     self._boltzmann_temperature = boltzmann_temperature
     self._optimizer = optimizer
-    self._td_errors_loss_fn = td_errors_loss_fn or element_wise_huber_loss
+    self._td_errors_loss_fn = td_errors_loss_fn or common.element_wise_huber_loss
     self._gamma = gamma
     self._reward_scale_factor = reward_scale_factor
     self._gradient_clipping = gradient_clipping
@@ -303,7 +291,7 @@ class DqnAgent(tf_agent.TFAgent):
 
   def _loss(self,
             experience,
-            td_errors_loss_fn=element_wise_huber_loss,
+            td_errors_loss_fn=common.element_wise_huber_loss,
             gamma=1.0,
             reward_scale_factor=1.0,
             weights=None):

--- a/tf_agents/agents/dqn/examples/v1/oog_train_eval.py
+++ b/tf_agents/agents/dqn/examples/v1/oog_train_eval.py
@@ -147,7 +147,7 @@ def train_eval(
       target_update_tau=target_update_tau,
       target_update_period=target_update_period,
       optimizer=tf.compat.v1.train.AdamOptimizer(learning_rate=learning_rate),
-      td_errors_loss_fn=dqn_agent.element_wise_squared_loss,
+      td_errors_loss_fn=common.element_wise_squared_loss,
       gamma=gamma,
       reward_scale_factor=reward_scale_factor,
       gradient_clipping=gradient_clipping,

--- a/tf_agents/agents/dqn/examples/v1/train_eval_atari.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_atari.py
@@ -291,7 +291,7 @@ class TrainEval(object):
             target_update_tau=target_update_tau,
             target_update_period=(
                 target_update_period / ATARI_FRAME_SKIP / self._update_period),
-            td_errors_loss_fn=dqn_agent.element_wise_huber_loss,
+            td_errors_loss_fn=common.element_wise_huber_loss,
             gamma=gamma,
             reward_scale_factor=reward_scale_factor,
             gradient_clipping=gradient_clipping,

--- a/tf_agents/agents/dqn/examples/v1/train_eval_gym.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_gym.py
@@ -133,7 +133,7 @@ def train_eval(
         epsilon_greedy=epsilon_greedy,
         target_update_tau=target_update_tau,
         target_update_period=target_update_period,
-        td_errors_loss_fn=dqn_agent.element_wise_squared_loss,
+        td_errors_loss_fn=common.element_wise_squared_loss,
         gamma=gamma,
         reward_scale_factor=reward_scale_factor,
         gradient_clipping=gradient_clipping,

--- a/tf_agents/agents/dqn/examples/v1/train_eval_rnn_gym.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_rnn_gym.py
@@ -136,7 +136,7 @@ def train_eval(
         epsilon_greedy=epsilon_greedy,
         target_update_tau=target_update_tau,
         target_update_period=target_update_period,
-        td_errors_loss_fn=dqn_agent.element_wise_squared_loss,
+        td_errors_loss_fn=common.element_wise_squared_loss,
         gamma=gamma,
         reward_scale_factor=reward_scale_factor,
         gradient_clipping=gradient_clipping,

--- a/tf_agents/agents/dqn/examples/v2/train_eval.py
+++ b/tf_agents/agents/dqn/examples/v2/train_eval.py
@@ -169,7 +169,7 @@ def train_eval(
         target_update_tau=target_update_tau,
         target_update_period=target_update_period,
         optimizer=tf.compat.v1.train.AdamOptimizer(learning_rate=learning_rate),
-        td_errors_loss_fn=dqn_agent.element_wise_squared_loss,
+        td_errors_loss_fn=common.element_wise_squared_loss,
         gamma=gamma,
         reward_scale_factor=reward_scale_factor,
         gradient_clipping=gradient_clipping,

--- a/tf_agents/colabs/1_dqn_tutorial.ipynb
+++ b/tf_agents/colabs/1_dqn_tutorial.ipynb
@@ -365,7 +365,7 @@
         "    train_env.action_spec(),\n",
         "    q_network=q_net,\n",
         "    optimizer=optimizer,\n",
-        "    td_errors_loss_fn=dqn_agent.element_wise_squared_loss,\n",
+        "    td_errors_loss_fn=common.element_wise_squared_loss,\n",
         "    train_step_counter=train_step_counter)\n",
         "tf_agent.initialize()"
       ]


### PR DESCRIPTION
The two function `element_wise_squared_loss` and `element_wise_huber_loss` is already in `utils/commons.py`, so redefining them in `dqn_agent.py` seems unnecessary.

https://github.com/tensorflow/agents/blob/96ca00544ca1f6524c89194afe272ebf07773b05/tf_agents/utils/common.py#L966

https://github.com/tensorflow/agents/blob/96ca00544ca1f6524c89194afe272ebf07773b05/tf_agents/utils/common.py#L971