### PR TITLE
Fixed: ActorDistributionNetwork crashes when action_spec is not a tensor_spec

### DIFF
--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -167,7 +167,7 @@ class ArraySpec(object):
       TypeError: If the shape is not an iterable or if the `dtype` is an invalid
         numpy dtype.
     """
-    self._shape = tuple(shape)
+    self._shape = tf.TensorShape(list(shape))
     self._dtype = np.dtype(dtype)
     self._name = name
 

--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -167,7 +167,7 @@ class ArraySpec(object):
       TypeError: If the shape is not an iterable or if the `dtype` is an invalid
         numpy dtype.
     """
-    self._shape = tf.TensorShape(list(shape))
+    self._shape = tf.TensorShape(shape)
     self._dtype = np.dtype(dtype)
     self._name = name
 

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -262,13 +262,13 @@ class ArraySpecTest(parameterized.TestCase):
   def testFromArray(self):
     spec = array_spec.ArraySpec.from_array(np.array([1, 2]), "test")
     self.assertEqual(spec.shape, (2,))
-    self.assertEqual(spec.dtype, np.int64)
+    self.assertEqual(spec.dtype, np.int32)
     self.assertEqual(spec.name, "test")
 
   def testFromArrayWithScalar(self):
     spec = array_spec.ArraySpec.from_array(5, "test")
     self.assertEqual(spec.shape, tuple())
-    self.assertEqual(spec.dtype, np.int64)
+    self.assertEqual(spec.dtype, np.int32)
     self.assertEqual(spec.name, "test")
 
   def testFromArrayWithNonNumeric(self):
@@ -515,6 +515,15 @@ class ArraySpecTypeTest(parameterized.TestCase):
     self.assertIs(
         tensor_spec.is_discrete(spec) ^ tensor_spec.is_continuous(spec), True)
 
+class ShapeArraySpecTest(parameterized.TestCase):
+
+  def testShapeHasNumElements(self):
+      spec = array_spec.ArraySpec((2, 3), dtype=np.int32)
+      self.assertEqual(6, spec.shape.num_elements())
+
+  def testShapeHasAsList(self):
+      spec = array_spec.ArraySpec((2, 3), dtype=np.int32)
+      self.assertEqual([2, 3], spec.shape.as_list())
 
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
This is my proposed fix to #197 as specified in the issue