### PR TITLE
Fix call to deprecated tf.random_uniform

### DIFF
--- a/tf_agents/colabs/2_environments_tutorial.ipynb
+++ b/tf_agents/colabs/2_environments_tutorial.ipynb
@@ -705,7 +705,7 @@
         "  episode_reward = 0\n",
         "  episode_steps = 0\n",
         "  while not time_step.is_last():\n",
-        "    action = tf.random_uniform([1], 0, 2, dtype=tf.int32)\n",
+        "    action = tf.random.uniform([1], 0, 2, dtype=tf.int32)\n",
         "    time_step = tf_env.step(action)\n",
         "    episode_steps += 1\n",
         "    episode_reward += time_step.reward.numpy()\n",


### PR DESCRIPTION
The use of `tf.random_uniform` in the Jupyter notebook `2_environments_tutorial.ipynb` leads to an error with the current version of TensorFlow. It has been changed to `tf.random.uniform` according to the [documentation](https://www.tensorflow.org/api_docs/python/tf/random/uniform).

Fixes #213 
