### PR TITLE
close envs in ParallelPyEnvironment when it closes

### DIFF
--- a/tf_agents/environments/parallel_py_environment.py
+++ b/tf_agents/environments/parallel_py_environment.py
@@ -380,6 +380,7 @@ class ProcessPyEnvironment(object):
           continue
         if message == self._CLOSE:
           assert payload is None
+          env.close()
           break
         raise KeyError('Received message of unknown type {}'.format(message))
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION

https://github.com/HorizonRobotics/alf/issues/206

In some scenarios, env itself is a  process or  multi-process,  ParallelPyEnvironment.close will hang , 
and resource will not be released 

