### PR TITLE
Fix SeedStream deprecation warning

### DIFF
--- a/tf_agents/specs/tensor_spec.py
+++ b/tf_agents/specs/tensor_spec.py
@@ -292,7 +292,7 @@ def sample_spec_nest(structure, seed=None, outer_dims=()):
     NotImplementedError: If `outer_dims` is not statically known but nest
       contains a `SparseTensorSpec`.
   """
-  seed_stream = tfd.SeedStream(seed=seed, salt="sample_spec_nest")
+  seed_stream = tfp.util.SeedStream(seed=seed, salt="sample_spec_nest")
 
   def sample_fn(spec):
     """Return a composite tensor sample given `spec`.


### PR DESCRIPTION
I encountered this deprecation warning, so I decided to go ahead and fix it.

```
W1018 16:37:54.586910 140155627402880 deprecation.py:323] From /home/felix/.venv/tf2/lib/python3.7/site-packages/tf_agents/specs/tensor_spec.py:295: SeedStream.__init__ (from tensorflow_probability.python.util.seed_stream) is deprecated and will be removed after 2019-10-01.
Instructions for updating:
SeedStream has moved to `tfp.util.SeedStream`.
```