### PR TITLE
Correction on misspell in "form" to "from"

### DIFF
--- a/tf_agents/colabs/5_replay_buffers_tutorial.ipynb
+++ b/tf_agents/colabs/5_replay_buffers_tutorial.ipynb
@@ -261,7 +261,7 @@
       },
       "source": [
         "\n",
-        "## Reading form the buffer\n",
+        "## Reading from the buffer\n",
         "\n",
         "There are three ways to read data from the `TFUniformReplayBuffer`:\n",
         "\n",


### PR DESCRIPTION
There is a misspell on line 264. It should be from instead of form.