### PR TITLE
Support for custom time_step_spec in TFPyEnviroment

### DIFF
--- a/tf_agents/environments/tf_py_environment.py
+++ b/tf_agents/environments/tf_py_environment.py
@@ -143,9 +143,8 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
           'wrapped environment are no longer guaranteed to happen in a common '
           'thread.  Environment: %s', (self._env,))
 
-    observation_spec = tensor_spec.from_spec(self._env.observation_spec())
     action_spec = tensor_spec.from_spec(self._env.action_spec())
-    time_step_spec = ts.time_step_spec(observation_spec)
+    time_step_spec = tensor_spec.from_spec(self._env.time_step_spec())
     batch_size = self._env.batch_size if self._env.batch_size else 1
 
     super(TFPyEnvironment, self).__init__(time_step_spec,


### PR DESCRIPTION
Currently, TFPyEnvironment creates a TensorSpec time_step_spec by calling TimeStep.time_step_spec(pyenv.observation_spec()). This precludes a PyEnvironment from using a non-standard time_step_spec and being wrapped into a TFPyEnviroment. 

I propose, instead, querying the PyEnvironment's time_step_spec directly and apply tensor_spec.from_spec().
---
time_step_spec from the environment's observation_spec. The latter
makes the possibly incorrect assumption that the environment does not
use a non-default time_step_spec.

(cherry picked from commit 363aa5c95c6de5048c26ecbff83feb4fcbae1631)