### PR TITLE
Create TFPyEnvironment time_step_spec from PyEnvironment's time_step_spec(), not observation_spec()

### DIFF
--- a/tf_agents/environments/tf_py_environment.py
+++ b/tf_agents/environments/tf_py_environment.py
@@ -143,9 +143,8 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
           'wrapped environment are no longer guaranteed to happen in a common '
           'thread.  Environment: %s', (self._env,))
 
-    observation_spec = tensor_spec.from_spec(self._env.observation_spec())
     action_spec = tensor_spec.from_spec(self._env.action_spec())
-    time_step_spec = ts.time_step_spec(observation_spec)
+    time_step_spec = tensor_spec.from_spec(self._env.time_step_spec())
     batch_size = self._env.batch_size if self._env.batch_size else 1
 
     super(TFPyEnvironment, self).__init__(time_step_spec,


### PR DESCRIPTION
Get time_step_spec from the environment's time_step_spec, not its
observation_spec. The latter makes the assumption that the PyEnvironment
uses the default time_step_spec structure, which is not necessarily
true.