### PR TITLE
Add trajectory arg to call fn for CounterMetric

### DIFF
--- a/tf_agents/metrics/py_metrics.py
+++ b/tf_agents/metrics/py_metrics.py
@@ -261,7 +261,8 @@ class CounterMetric(py_metric.PyMetric):
   def reset(self):
     self._np_state.count = np.int64(0)
 
-  def call(self):
+  def call(self, trajectory):
+    del trajectory  # unused
     self._np_state.count += 1
 
   def result(self):


### PR DESCRIPTION
Added trajectory as argument for CounterMetric.call to enable compatibility with TFPyMetric wrapper.