### PR TITLE
Eps Greedy Policy fix for policy info containing tensors of rank > 1.

### DIFF
--- a/tf_agents/policies/epsilon_greedy_policy.py
+++ b/tf_agents/policies/epsilon_greedy_policy.py
@@ -105,7 +105,7 @@ class EpsilonGreedyPolicy(tf_policy.Base):
     if greedy_action.info:
       if not random_action.info:
         raise ValueError('Incompatible info field')
-      info = nest_utils.wherev2(cond, greedy_action.info, random_action.info)
+      info = nest_utils.where(cond, greedy_action.info, random_action.info)
     else:
       if random_action.info:
         raise ValueError('Incompatible info field')

--- a/tf_agents/policies/epsilon_greedy_policy.py
+++ b/tf_agents/policies/epsilon_greedy_policy.py
@@ -105,9 +105,7 @@ class EpsilonGreedyPolicy(tf_policy.Base):
     if greedy_action.info:
       if not random_action.info:
         raise ValueError('Incompatible info field')
-      info = tf.nest.map_structure(
-          lambda a, b: tf.where(cond, a, b),
-          greedy_action.info, random_action.info)
+      info = nest_utils.wherev2(cond, greedy_action.info, random_action.info)
     else:
       if random_action.info:
         raise ValueError('Incompatible info field')

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -556,3 +556,26 @@ def where(condition, true_outputs, false_outputs):
   """
   return tf.nest.map_structure(lambda t, f: tf.compat.v1.where(condition, t, f),
                                true_outputs, false_outputs)
+
+def wherev2(condition, true_outputs, false_outputs):
+  """Generalization of tf.where where supporting nests as the outputs.
+
+
+  Args:
+    condition: A boolean Tensor of shape [B,].
+    true_outputs: Tensor or nested tuple of Tensors of any dtype, each with
+      shape [B, ...], to be split based on `condition`.
+    false_outputs: Tensor or nested tuple of Tensors of any dtype, each with
+      shape [B, ...], to be split based on `condition`.
+
+  Returns:
+    Interleaved output from `true_outputs` and `false_outputs` based on
+    `condition`.
+  """
+  return tf.nest.map_structure(
+    lambda t, f: tf.where(
+      # Under semantics of tf.where v2, cond must have same rank as a/b. Differs from tf.compat.v1.where.
+      tf.reshape(condition,
+                 tf.concat([tf.shape(condition), tf.ones(tf.rank(t) - tf.rank(condition), dtype=tf.int32)], axis=0)),
+      t, f),
+    true_outputs, false_outputs)

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -560,10 +560,10 @@ def where(condition, true_outputs, false_outputs):
     Interleaved output from `true_outputs` and `false_outputs` based on
     `condition`.
   """
-  def where_with_matching_ranks(t, f):
+  def _where_with_matching_ranks(t, f):
       rank_difference = tf.rank(t) - tf.rank(condition)
       condition_shape = tf.concat([tf.shape(condition), tf.ones(rank_difference, dtype=tf.int32)], axis=0)
       reshaped_condition = tf.reshape(condition, condition_shape)
       return tf.where(reshaped_condition, t, f)
 
-  return tf.nest.map_structure(where_with_matching_ranks, true_outputs, false_outputs)
+  return tf.nest.map_structure(_where_with_matching_ranks, true_outputs, false_outputs)

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -560,9 +560,10 @@ def where(condition, true_outputs, false_outputs):
     Interleaved output from `true_outputs` and `false_outputs` based on
     `condition`.
   """
-  return tf.nest.map_structure(
-    lambda t, f: tf.where(
-      tf.reshape(condition,
-                 tf.concat([tf.shape(condition), tf.ones(tf.rank(t) - tf.rank(condition), dtype=tf.int32)], axis=0)),
-      t, f),
-    true_outputs, false_outputs)
+  def where_with_matching_ranks(t, f):
+      rank_difference = tf.rank(t) - tf.rank(condition)
+      condition_shape = tf.concat([tf.shape(condition), tf.ones(rank_difference, dtype=tf.int32)], axis=0)
+      reshaped_condition = tf.reshape(condition, condition_shape)
+      return tf.where(reshaped_condition, t, f)
+
+  return tf.nest.map_structure(where_with_matching_ranks, true_outputs, false_outputs)

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -539,27 +539,10 @@ def get_outer_array_shape(nested_array, spec):
   return first_array.shape[:num_outer_dims]
 
 
+
 def where(condition, true_outputs, false_outputs):
-  """Generalization of tf.compat.v1.where supporting nests as the outputs.
-
-
-  Args:
-    condition: A boolean Tensor of shape [B,].
-    true_outputs: Tensor or nested tuple of Tensors of any dtype, each with
-      shape [B, ...], to be split based on `condition`.
-    false_outputs: Tensor or nested tuple of Tensors of any dtype, each with
-      shape [B, ...], to be split based on `condition`.
-
-  Returns:
-    Interleaved output from `true_outputs` and `false_outputs` based on
-    `condition`.
-  """
-  return tf.nest.map_structure(lambda t, f: tf.compat.v1.where(condition, t, f),
-                               true_outputs, false_outputs)
-
-def wherev2(condition, true_outputs, false_outputs):
   """Generalization of tf.where where, returning a nest constructed though
-  application of tf.where to the input nests' constituent Tensors.
+  application of tf.where to the input nests.
 
   Args:
     condition: A boolean Tensor of shape [B, ...]. The shape of condition
@@ -579,7 +562,6 @@ def wherev2(condition, true_outputs, false_outputs):
   """
   return tf.nest.map_structure(
     lambda t, f: tf.where(
-      # Under semantics of tf.where v2, cond must have same rank as a/b. This differs from tf.compat.v1.where.
       tf.reshape(condition,
                  tf.concat([tf.shape(condition), tf.ones(tf.rank(t) - tf.rank(condition), dtype=tf.int32)], axis=0)),
       t, f),

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -558,11 +558,16 @@ def where(condition, true_outputs, false_outputs):
                                true_outputs, false_outputs)
 
 def wherev2(condition, true_outputs, false_outputs):
-  """Generalization of tf.where where supporting nests as the outputs.
-
+  """Generalization of tf.where where, returning a nest constructed though
+  application of tf.where to the input nests' constituent Tensors.
 
   Args:
-    condition: A boolean Tensor of shape [B,].
+    condition: A boolean Tensor of shape [B, ...]. The shape of condition
+      must be equal to or a prefix of the shape of true_outputs and
+      false_outputs. If condition's rank is smaller than the rank of
+      true_outputs and false_outputs, dimensions of size 1 are added to
+      condition to make its rank match that of true_outputs and
+      false_outputs in order to satisfy the requirements of tf.where.
     true_outputs: Tensor or nested tuple of Tensors of any dtype, each with
       shape [B, ...], to be split based on `condition`.
     false_outputs: Tensor or nested tuple of Tensors of any dtype, each with
@@ -574,7 +579,7 @@ def wherev2(condition, true_outputs, false_outputs):
   """
   return tf.nest.map_structure(
     lambda t, f: tf.where(
-      # Under semantics of tf.where v2, cond must have same rank as a/b. Differs from tf.compat.v1.where.
+      # Under semantics of tf.where v2, cond must have same rank as a/b. This differs from tf.compat.v1.where.
       tf.reshape(condition,
                  tf.concat([tf.shape(condition), tf.ones(tf.rank(t) - tf.rank(condition), dtype=tf.int32)], axis=0)),
       t, f),

--- a/tf_agents/utils/nest_utils_test.py
+++ b/tf_agents/utils/nest_utils_test.py
@@ -680,18 +680,29 @@ class NestedArraysTest(tf.test.TestCase):
     expected = (np.array([0, 1, 1, 0, 1]), np.array([1, 7, 8, 4, 10]))
     self.assertAllEqual(expected, result)
 
-  def testWhereV2(self):
+  def testWhereDifferentRanks(self):
     condition = tf.convert_to_tensor([True, False, False, True, False])
     true_output = tf.nest.map_structure(tf.convert_to_tensor,
                                         (np.reshape(np.array([0] * 10), (5, 2)), np.reshape(np.arange(1, 11), (5, 2))))
     false_output = tf.nest.map_structure(tf.convert_to_tensor,
                                          (np.reshape(np.array([1] * 10), (5, 2)), np.reshape(np.arange(12, 22), (5, 2))))
 
-    result = nest_utils.wherev2(condition, true_output, false_output)
+    result = nest_utils.where(condition, true_output, false_output)
     result = self.evaluate(result)
 
     expected = (np.array([[0, 0], [1, 1], [1, 1], [0, 0], [1, 1]]),
                 np.array([[1, 2], [14, 15], [16, 17], [7, 8], [20, 21]]))
+    self.assertAllEqual(expected, result)
+
+  def testWhereSameRankDifferentDimension(self):
+    condition = tf.convert_to_tensor([True, False, True])
+    true_output = (tf.convert_to_tensor([1]), tf.convert_to_tensor([2]))
+    false_output = (tf.convert_to_tensor([3, 4, 5]), tf.convert_to_tensor([6, 7, 8]))
+
+    result = nest_utils.where(condition, true_output, false_output)
+    result = self.evaluate(result)
+
+    expected = (np.array([1, 4, 1]), np.array([2, 7, 2]))
     self.assertAllEqual(expected, result)
 
 

--- a/tf_agents/utils/nest_utils_test.py
+++ b/tf_agents/utils/nest_utils_test.py
@@ -680,6 +680,20 @@ class NestedArraysTest(tf.test.TestCase):
     expected = (np.array([0, 1, 1, 0, 1]), np.array([1, 7, 8, 4, 10]))
     self.assertAllEqual(expected, result)
 
+  def testWhereV2(self):
+    condition = tf.convert_to_tensor([True, False, False, True, False])
+    true_output = tf.nest.map_structure(tf.convert_to_tensor,
+                                        (np.reshape(np.array([0] * 10), (5, 2)), np.reshape(np.arange(1, 11), (5, 2))))
+    false_output = tf.nest.map_structure(tf.convert_to_tensor,
+                                         (np.reshape(np.array([1] * 10), (5, 2)), np.reshape(np.arange(12, 22), (5, 2))))
+
+    result = nest_utils.wherev2(condition, true_output, false_output)
+    result = self.evaluate(result)
+
+    expected = (np.array([[0, 0], [1, 1], [1, 1], [0, 0], [1, 1]]),
+                np.array([[1, 2], [14, 15], [16, 17], [7, 8], [20, 21]]))
+    self.assertAllEqual(expected, result)
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Semantics of tf.where in v2 differ from tf.compat.v1.where, as condition
rank must match true/false tensors. Addressed by adding
nest_utils.where2 rather than reverting to tf.compat.v1 so that
condition can eventually have rank > 1 (as suggested by
TODO(b/133175894).