### PR TITLE
Support for 'training' flag (for dropout) in DQN Agent.

### DIFF
--- a/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
+++ b/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
@@ -257,6 +257,9 @@ class CategoricalDqnAgent(dqn_agent.DqnAgent):
       gamma: Discount for future rewards.
       reward_scale_factor: Multiplicative factor to scale rewards.
       weights: Optional weights used for importance sampling.
+      training: A boolean indicating whether the loss is being calculated in
+        training or inference mode. The flag is propagated to the q_network's
+        call() method.
     Returns:
       critic_loss: A scalar critic loss.
     Raises:

--- a/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
+++ b/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
@@ -238,7 +238,8 @@ class CategoricalDqnAgent(dqn_agent.DqnAgent):
             td_errors_loss_fn=tf.compat.v1.losses.huber_loss,
             gamma=1.0,
             reward_scale_factor=1.0,
-            weights=None):
+            weights=None,
+            training=False):
     """Computes critic loss for CategoricalDQN training.
 
     See Algorithm 1 and the discussion immediately preceding it in page 6 of
@@ -300,7 +301,8 @@ class CategoricalDqnAgent(dqn_agent.DqnAgent):
                 network_observation))
 
       # q_logits contains the Q-value logits for all actions.
-      q_logits, _ = self._q_network(network_observation, time_steps.step_type)
+      q_logits, _ = self._q_network(network_observation, time_steps.step_type,
+                                    training=training)
 
       if batch_squash is not None:
         # Squash outer dimensions to a single dimensions for facilitation

--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -509,7 +509,7 @@ class DqnAgent(tf_agent.TFAgent):
       network_observation, _ = self._observation_and_action_constraint_splitter(
           network_observation)
 
-    q_values, _ = self._q_network(network_observation, time_steps.step_type)
+    q_values, _ = self._q_network(network_observation, time_steps.step_type, training=True)
     # Handle action_spec.shape=(), and shape=(1,) by using the multi_dim_actions
     # param. Note: assumes len(tf.nest.flatten(action_spec)) == 1.
     multi_dim_actions = self._action_spec.shape.rank > 0
@@ -534,7 +534,7 @@ class DqnAgent(tf_agent.TFAgent):
           network_observation)
 
     next_target_q_values, _ = self._target_q_network(
-        network_observation, next_time_steps.step_type)
+        network_observation, next_time_steps.step_type, training=False)
     batch_size = (
         next_target_q_values.shape[0] or tf.shape(next_target_q_values)[0])
     dummy_state = self._target_greedy_policy.get_initial_state(batch_size)
@@ -581,7 +581,7 @@ class DdqnAgent(DqnAgent):
           network_observation)
 
     next_target_q_values, _ = self._target_q_network(
-        network_observation, next_time_steps.step_type)
+        network_observation, next_time_steps.step_type, training=False)
     batch_size = (
         next_target_q_values.shape[0] or tf.shape(next_target_q_values)[0])
     dummy_state = self._policy.get_initial_state(batch_size)

--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -40,7 +40,7 @@ from tf_agents.utils import common
 from tf_agents.utils import composite
 from tf_agents.utils import eager_utils
 from tf_agents.utils import nest_utils
-from tf_agents import utils
+import tf_agents.utils.training
 from tf_agents.utils import value_ops
 
 
@@ -370,7 +370,7 @@ class DqnAgent(tf_agent.TFAgent):
                                           self.train_step_counter)
       eager_utils.add_gradients_summaries(grads_and_vars,
                                           self.train_step_counter)
-    utils.training.apply_gradients(
+    tf_agents.utils.training.apply_gradients(
         self._optimizer, grads_and_vars, global_step=self.train_step_counter)
 
     self._update_target()

--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -40,7 +40,7 @@ from tf_agents.utils import common
 from tf_agents.utils import composite
 from tf_agents.utils import eager_utils
 from tf_agents.utils import nest_utils
-from tf_agents.utils import training
+from tf_agents import utils
 from tf_agents.utils import value_ops
 
 
@@ -370,7 +370,7 @@ class DqnAgent(tf_agent.TFAgent):
                                           self.train_step_counter)
       eager_utils.add_gradients_summaries(grads_and_vars,
                                           self.train_step_counter)
-    training.apply_gradients(
+    utils.training.apply_gradients(
         self._optimizer, grads_and_vars, global_step=self.train_step_counter)
 
     self._update_target()

--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -350,7 +350,8 @@ class DqnAgent(tf_agent.TFAgent):
           td_errors_loss_fn=self._td_errors_loss_fn,
           gamma=self._gamma,
           reward_scale_factor=self._reward_scale_factor,
-          weights=weights)
+          weights=weights,
+          training=True)
     tf.debugging.check_numerics(loss_info[0], 'Loss is inf or nan')
     variables_to_train = self._q_network.trainable_weights
     non_trainable_weights = self._q_network.non_trainable_weights
@@ -381,7 +382,8 @@ class DqnAgent(tf_agent.TFAgent):
             td_errors_loss_fn=common.element_wise_huber_loss,
             gamma=1.0,
             reward_scale_factor=1.0,
-            weights=None):
+            weights=None,
+            training=False):
     """Computes loss for DQN training.
 
     Args:
@@ -397,6 +399,10 @@ class DqnAgent(tf_agent.TFAgent):
       weights: Optional scalar or elementwise (per-batch-entry) importance
         weights.  The output td_loss will be scaled by these weights, and
         the final scalar loss is the mean of these values.
+      training: A boolean indicating whether the loss is being calculated in
+        training mode or inference mode. This parameter is passed to the call
+        method of the QNetwork which subsequently will pass it to the call
+        method of its constituent layers.
 
     Returns:
       loss: An instance of `DqnLossInfo`.

--- a/tf_agents/networks/categorical_q_network.py
+++ b/tf_agents/networks/categorical_q_network.py
@@ -129,6 +129,9 @@ class CategoricalQNetwork(network.Network):
       step_type: The step type for the given observation. See `StepType` in
         time_step.py.
       network_state: A state tuple to pass to the network, mainly used by RNNs.
+      training: A boolean indicating whether the network is operating in
+        training or inference mode. The flag is propagated to the q_network's
+        call() method.
 
     Returns:
       A tuple `(logits, network_state)`.

--- a/tf_agents/networks/categorical_q_network.py
+++ b/tf_agents/networks/categorical_q_network.py
@@ -121,7 +121,7 @@ class CategoricalQNetwork(network.Network):
   def num_atoms(self):
     return self._num_atoms
 
-  def call(self, observation, step_type=None, network_state=()):
+  def call(self, observation, step_type=None, network_state=(), training=False):
     """Runs the given observation through the network.
 
     Args:
@@ -134,6 +134,6 @@ class CategoricalQNetwork(network.Network):
       A tuple `(logits, network_state)`.
     """
     logits, network_state = self._q_network(
-        observation, step_type, network_state)
+        observation, step_type, network_state, training=training)
     logits = tf.reshape(logits, [-1, self._num_actions, self._num_atoms])
     return logits, network_state

--- a/tf_agents/networks/dynamic_unroll_layer.py
+++ b/tf_agents/networks/dynamic_unroll_layer.py
@@ -296,7 +296,7 @@ class DynamicUnroll(tf.keras.layers.Layer):
 
     if not tf.is_tensor(iterations) and iterations == 1:
       # Take exactly one time step
-      state = _static_unroll_single_step(
+      outputs, final_state = _static_unroll_single_step(
         self.cell,
         inputs,
         reset_mask,
@@ -304,7 +304,7 @@ class DynamicUnroll(tf.keras.layers.Layer):
         zero_state=zero_state,
         training=training)
     else:
-      state = _dynamic_unroll_multi_step(
+      outputs, final_state = _dynamic_unroll_multi_step(
         self.cell,
         inputs,
         reset_mask,
@@ -321,7 +321,7 @@ class DynamicUnroll(tf.keras.layers.Layer):
       self.cell.reset_dropout_mask()
       self.cell.reset_recurrent_dropout_mask()
 
-    return state
+    return outputs, final_state
 
 
 def _maybe_reset_state(reset, s_zero, s):

--- a/tf_agents/networks/lstm_encoding_network.py
+++ b/tf_agents/networks/lstm_encoding_network.py
@@ -220,7 +220,8 @@ class LSTMEncodingNetwork(network.Network):
     state, network_state = self._dynamic_unroll(
         state,
         reset_mask,
-        initial_state=network_state)
+        initial_state=network_state,
+        training=training)
 
     for layer in self._output_encoder:
       state = layer(state, training=training)

--- a/tf_agents/networks/lstm_encoding_network.py
+++ b/tf_agents/networks/lstm_encoding_network.py
@@ -181,7 +181,7 @@ class LSTMEncodingNetwork(network.Network):
     self._dynamic_unroll = dynamic_unroll_layer.DynamicUnroll(cell)
     self._output_encoder = output_encoder
 
-  def call(self, observation, step_type, network_state=None):
+  def call(self, observation, step_type, network_state=None, training=False):
     """Apply the network.
 
     Args:
@@ -211,7 +211,7 @@ class LSTMEncodingNetwork(network.Network):
                                         step_type)
 
     state, network_state = self._input_encoder(
-        observation, step_type, network_state)
+        observation, step_type, network_state, training=training)
 
     with tf.name_scope('reset_mask'):
       reset_mask = tf.equal(step_type, time_step.StepType.FIRST)
@@ -223,7 +223,7 @@ class LSTMEncodingNetwork(network.Network):
         initial_state=network_state)
 
     for layer in self._output_encoder:
-      state = layer(state)
+      state = layer(state, training=training)
 
     if not has_time_dim:
       # Remove time dimension from the state.

--- a/tf_agents/networks/q_network.py
+++ b/tf_agents/networks/q_network.py
@@ -129,7 +129,7 @@ class QNetwork(network.Network):
     self._encoder = encoder
     self._q_value_layer = q_value_layer
 
-  def call(self, observation, step_type=None, network_state=()):
+  def call(self, observation, step_type=None, network_state=(), training=False):
     """Runs the given observation through the network.
 
     Args:
@@ -142,5 +142,6 @@ class QNetwork(network.Network):
       A tuple `(logits, network_state)`.
     """
     state, network_state = self._encoder(
-        observation, step_type=step_type, network_state=network_state)
+        observation, step_type=step_type, network_state=network_state,
+        training=training)
     return self._q_value_layer(state), network_state

--- a/tf_agents/networks/q_network.py
+++ b/tf_agents/networks/q_network.py
@@ -137,6 +137,9 @@ class QNetwork(network.Network):
       step_type: The step type for the given observation. See `StepType` in
         time_step.py.
       network_state: A state tuple to pass to the network, mainly used by RNNs.
+      training: Python boolean indicating whether the network should behave in
+      training mode or in inference mode. This argument is passed to the
+      encoding network when calling it and is used for encoder dropout layers.
 
     Returns:
       A tuple `(logits, network_state)`.

--- a/tf_agents/networks/q_network.py
+++ b/tf_agents/networks/q_network.py
@@ -137,10 +137,9 @@ class QNetwork(network.Network):
       step_type: The step type for the given observation. See `StepType` in
         time_step.py.
       network_state: A state tuple to pass to the network, mainly used by RNNs.
-      training: Python boolean indicating whether the network should behave in
-      training mode or in inference mode. This argument is passed to the
-      encoding network when calling it and is used for encoder dropout layers.
-
+      training: A boolean indicating whether the network should behave in
+        training mode or in inference mode. This flag is propagated to the
+        encoding network which further propagates it to its child layers.
     Returns:
       A tuple `(logits, network_state)`.
     """

--- a/tf_agents/networks/q_network_test.py
+++ b/tf_agents/networks/q_network_test.py
@@ -257,7 +257,7 @@ class SingleObservationSingleActionTest(tf.test.TestCase, parameterized.TestCase
 
     obs_spec = tensor_spec.TensorSpec([num_obs_dims], tf.float32)
     action_spec = tensor_spec.BoundedTensorSpec(
-        shape=(), minimum=0, maximum=num_actions,  dtype=tf.int32)
+        shape=(), minimum=0, maximum=num_actions-1,  dtype=tf.int32)
     q_net = q_network.QNetwork(
         input_tensor_spec=obs_spec,
         action_spec=action_spec,


### PR DESCRIPTION
Pass 'training' boolean to q_network/q_rnn_network/categorical_q_network and propagate as appropriate. Also capture q_network.losses into DQNAgent's loss before the q_network is called again to calculate Ddqn targets and the losses are reset.