### PR TITLE
Remove py2 builds.

### DIFF
--- a/pip_pkg.sh
+++ b/pip_pkg.sh
@@ -37,7 +37,7 @@ DEST=$(cd "$DEST" && pwd)
 # specifies the output dir) to setup.py, e.g.,
 #  ./pip_pkg /tmp/tf_agents_pkg --release
 # passes `--release` to setup.py.
-python setup.py bdist_wheel --universal ${@:2} --dist-dir="$DEST" >/dev/null
+python setup.py bdist_wheel ${@:2} --dist-dir="$DEST" >/dev/null
 
 set +x
 echo -e "\nBuild complete. Wheel files are in $DEST"

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,8 @@ setup(
     install_requires=REQUIRED_PACKAGES,
     tests_require=TEST_REQUIRED_PACKAGES,
     extras_require={'tests': TEST_REQUIRED_PACKAGES},
+    # Supports Python 3 only.
+    python_requires='>=3',
     # Add in any packaged data.
     zip_safe=False,
     distclass=BinaryDistribution,
@@ -216,8 +218,6 @@ setup(
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests_release.sh
+++ b/tests_release.sh
@@ -35,9 +35,7 @@ run_tests() {
   # TensorFlow isn't a regular dependency because there are many different pip
   # packages a user might have installed.
   if [[ $2 == "nightly" ]] ; then
-    pip install tf-nightly==1.15.0.dev20190821 \
-      tf-estimator-nightly==1.14.0.dev2019091701 \
-      gast==0.2.2
+    pip install tf-nightly
 
     # Run the tests
     python setup.py test
@@ -54,15 +52,6 @@ run_tests() {
     # Install tf_agents package.
     WHEEL_PATH=${TMP}/wheel/$1
     ./pip_pkg.sh ${WHEEL_PATH}/ --release
-  elif [[ $2 == "preview" ]] ; then
-    pip install tf-nightly-2.0-preview
-
-    # Run the tests
-    python setup.py test
-
-    # Install tf_agents package.
-    WHEEL_PATH=${TMP}/wheel/$1
-    ./pip_pkg.sh ${WHEEL_PATH}/
   else
     echo "Error unknow option only [nightly|stable]"
     exit
@@ -86,8 +75,6 @@ if ! which cmake > /dev/null; then
    fi
 fi
 
-# Test on Python2.7
-run_tests "2.7" $1
 # Test on Python3.6.1
 run_tests "3.6.1" $1
 


### PR DESCRIPTION
The removes testing of python 2 from the release script and creates a wheel file that is python3 only.  