### PR TITLE
Set TFPyEnv's reward shape per wrapped env's time_step_spec.

### DIFF
--- a/tf_agents/environments/tf_py_environment.py
+++ b/tf_agents/environments/tf_py_environment.py
@@ -151,9 +151,12 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
                                           action_spec,
                                           batch_size)
 
-    # Gather all the dtypes of the elements in time_step.
+    # Gather all the dtypes and shapes of the elements in time_step.
     self._time_step_dtypes = [
         s.dtype for s in tf.nest.flatten(self.time_step_spec())
+    ]
+    self._time_step_shapes = [
+        s.shape for s in tf.nest.flatten(self.time_step_spec())
     ]
 
     self._time_step = None
@@ -208,7 +211,7 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     Returns:
       A `TimeStep` tuple of:
         step_type: A scalar int32 tensor representing the `StepType` value.
-        reward: A scalar float32 tensor representing the reward at this
+        reward: A float32 tensor representing the reward at this
           timestep.
         discount: A scalar float32 tensor representing the discount [0, 1].
         observation: A Tensor, or a nested dict, list or tuple of Tensors
@@ -244,7 +247,7 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     Returns:
       A `TimeStep` tuple of:
         step_type: A scalar int32 tensor representing the `StepType` value.
-        reward: A scalar float32 tensor representing the reward at this
+        reward: A float32 tensor representing the reward at this
           timestep.
         discount: A scalar float32 tensor representing the discount [0, 1].
         observation: A Tensor, or a nested dict, list or tuple of Tensors
@@ -280,7 +283,7 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     Returns:
       A `TimeStep` tuple of:
         step_type: A scalar int32 tensor representing the `StepType` value.
-        reward: A scalar float32 tensor representing the reward at this
+        reward: A float32 tensor representing the reward at this
           time_step.
         discount: A scalar float32 tensor representing the discount [0, 1].
         observation: A Tensor, or a nested dict, list or tuple of Tensors
@@ -333,7 +336,7 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     batch_shape = tf.TensorShape(batch_shape)
     if not tf.executing_eagerly():
       # Shapes are not required in eager mode.
-      reward.set_shape(batch_shape)
+      reward.set_shape(batch_shape.concatenate(self._time_step_shapes[1]))
       step_type.set_shape(batch_shape)
       discount.set_shape(batch_shape)
     # Give each tensor a meaningful name and set the static shape.

--- a/tf_agents/environments/tf_py_environment.py
+++ b/tf_agents/environments/tf_py_environment.py
@@ -155,9 +155,6 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     self._time_step_dtypes = [
         s.dtype for s in tf.nest.flatten(self.time_step_spec())
     ]
-    self._time_step_shapes = [
-        s.shape for s in tf.nest.flatten(self.time_step_spec())
-    ]
 
     self._time_step = None
     self._lock = threading.Lock()
@@ -336,7 +333,8 @@ class TFPyEnvironment(tf_environment.TFEnvironment):
     batch_shape = tf.TensorShape(batch_shape)
     if not tf.executing_eagerly():
       # Shapes are not required in eager mode.
-      reward.set_shape(batch_shape.concatenate(self._time_step_shapes[1]))
+      reward.set_shape(batch_shape.concatenate(
+        self.time_step_spec().reward.shape))
       step_type.set_shape(batch_shape)
       discount.set_shape(batch_shape)
     # Give each tensor a meaningful name and set the static shape.


### PR DESCRIPTION
This allows environments to have non-scalar rewards.
Relates to https://github.com/tensorflow/agents/pull/239.