### PR TITLE
Update common.replicate to support replicating scalar tensors

### DIFF
--- a/tf_agents/utils/common.py
+++ b/tf_agents/utils/common.py
@@ -998,12 +998,18 @@ def replicate(tensor, outer_shape):
   if outer_ndims == 0:
     return tensor
 
+  # Calculate target shape of replicated tensor
+  target_shape = tf.concat([outer_shape, tf.shape(input=tensor)], axis=0)
+
+  # tf.tile expects `tensor` to be at least 1D
+  if tensor_ndims == 0:
+    tensor = tensor[None]
+
   # Replicate tensor "t" along the 1st dimension.
   tiled_tensor = tf.tile(tensor, [tf.reduce_prod(input_tensor=outer_shape)] +
                          [1] * (tensor_ndims - 1))
 
   # Reshape to match outer_shape.
-  target_shape = tf.concat([outer_shape, tf.shape(input=tensor)], axis=0)
   return tf.reshape(tiled_tensor, target_shape)
 
 

--- a/tf_agents/utils/common_test.py
+++ b/tf_agents/utils/common_test.py
@@ -794,6 +794,15 @@ class ReplicateTensorTest(test_utils.TestCase, parameterized.TestCase):
       self.assertEqual(tf.TensorShape(outer_shape + list(value.shape)),
                        replicated_value.shape)
 
+  def testReplicateScalarTensor(self):
+    value = 1
+    outer_shape = [2, 1]
+    expected_replicated_value = np.array([[value], [value]])
+
+    tf_value = tf.constant(value, shape=())
+    replicated_value = self.evaluate(common.replicate(tf_value, outer_shape))
+    self.assertAllEqual(expected_replicated_value, replicated_value)
+
 
 class FunctionTest(test_utils.TestCase):
 


### PR DESCRIPTION
The function `common.replicate` uses the TensorFlow function `tile` to duplicate the input tensor. The `tile` function requires that the input tensor be at least a 1D tensor. 

This PR updates the `common.replicate` function to support replicating scalar tensors over the batch dimensions.