### PR TITLE
Remove uses of `tf.compat.v1.scatter_update`

### DIFF
--- a/tf_agents/replay_buffers/table.py
+++ b/tf_agents/replay_buffers/table.py
@@ -126,8 +126,8 @@ class Table(tf.Module):
     flattened_slots = tf.nest.flatten(slots)
     flattened_values = tf.nest.flatten(values)
     write_ops = [
-        tf.compat.v1.scatter_update(self._slot2storage_map[slot], rows,
-                                    value).op
+        (self._slot2storage_map[slot].scatter_update(
+          tf.IndexedSlices(value, rows))).op
         for (slot, value) in zip(flattened_slots, flattened_values)
     ]
     return tf.group(*write_ops)


### PR DESCRIPTION
This PR was raised in order to partially fix #298 .

This PR removes the use of the Tf-1.0 function (that is throwing the exceptions mentioned in that issue) from TF-Agents. However, following this change, that issue has not yet been resolved. It would appear that a follow-up change to TensorFlow is necessary to completely solve that issue.