### PR TITLE
Update uses of deprecated AffineScalar bijector.

### DIFF
--- a/tf_agents/bandits/environments/mushroom_environment_utilities.py
+++ b/tf_agents/bandits/environments/mushroom_environment_utilities.py
@@ -129,8 +129,9 @@ def mushroom_reward_distribution(r_noeat, r_eat_safe, r_eat_poison_bad,
   # to the desired values.
 
   distr = tfd.Bernoulli(probs=[[0, prob_poison_bad], [0, 0]], dtype=tf.float32)
-  reward_distr = tfp.bijectors.AffineScalar(
-      shift=[[r_noeat, r_eat_poison_bad], [r_noeat, r_eat_safe]],
-      scale=[[1, r_eat_poison_good - r_eat_poison_bad], [1, 1]])(
-          distr)
+  reward_distr = tfp.bijectors.Shift(
+    [[r_noeat, r_eat_poison_bad], [r_noeat, r_eat_safe]]
+  )(tfp.bijectors.Scale(
+    [[1, r_eat_poison_good - r_eat_poison_bad], [1, 1]]
+  )(distr))
   return tfd.Independent(reward_distr, reinterpreted_batch_ndims=2)

--- a/tf_agents/bandits/environments/mushroom_environment_utilities_test.py
+++ b/tf_agents/bandits/environments/mushroom_environment_utilities_test.py
@@ -34,6 +34,12 @@ class MushroomEnvironmentUtilitiesTest(tf.test.TestCase):
                 [1, 0, 1, 0, 0]]
     np.testing.assert_array_equal(encoded, expected)
 
+  def testRewardDistribution(self):
+    reward_distr = mushroom_environment_utilities.mushroom_reward_distribution(
+      r_noeat=0.0, r_eat_safe=5.0, r_eat_poison_bad=-35.0,
+      r_eat_poison_good=5.0, prob_poison_bad=0.5)
+    np.testing.assert_array_equal(reward_distr.mean(), [[0, -15.], [0, 5.]])
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tf_agents/distributions/utils.py
+++ b/tf_agents/distributions/utils.py
@@ -88,8 +88,8 @@ class SquashToSpecNormal(tfp.distributions.Distribution):
     self.input_distribution = distribution
 
     bijectors = [
-        tfp.bijectors.AffineScalar(
-            shift=self.action_means, scale=self.action_magnitudes),
+        tfp.bijectors.Shift(self.action_means)(tfp.bijectors.Scale(
+          self.action_magnitudes)),
         tanh_bijector_stable.Tanh()
     ]
     bijector_chain = tfp.bijectors.Chain(bijectors)


### PR DESCRIPTION
The AffineScalar bijector is marked as deprecated. Uses of this bijector has been updated, and a test has been added.

fix #365 .