### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/tf_agents/policies/tf_policy.py
+++ b/tf_agents/policies/tf_policy.py
@@ -239,7 +239,7 @@ class TFPolicy(tf.Module):
     return self._get_initial_state(batch_size)
 
   def _maybe_reset_state(self, time_step, policy_state):
-    if policy_state is ():  # pylint: disable=literal-comparison
+    if policy_state == ():
       return policy_state
 
     batch_size = tf.compat.dimension_value(time_step.discount.shape[0])


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> () is ()
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```