### PR TITLE
Remove imports from __future__.

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -23,10 +23,6 @@ python build_docs.py --output_dir=/path/to/output
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 

--- a/docs/tutorials/colab_kernel_init.py
+++ b/docs/tutorials/colab_kernel_init.py
@@ -16,11 +16,6 @@
 # Lint as: python3
 """Initialization code for colab test."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import glob
 import logging
 import os

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Install tf_agents."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import codecs
 import datetime
 import fnmatch

--- a/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent.py
+++ b/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent.py
@@ -20,11 +20,6 @@ Implements generic form of behavioral cloning.
 Users must provide their own loss functions.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Optional, Text
 

--- a/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent_test.py
+++ b/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for agents.behavioral_cloning.behavioral_cloning_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
+++ b/tf_agents/agents/categorical_dqn/categorical_dqn_agent.py
@@ -22,11 +22,6 @@ Implements the Categorical DQN agent from
   https://arxiv.org/abs/1707.06887
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/agents/categorical_dqn/categorical_dqn_agent_test.py
+++ b/tf_agents/agents/categorical_dqn/categorical_dqn_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for agents.dqn.categorical_dqn_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.agents.categorical_dqn import categorical_dqn_agent

--- a/tf_agents/agents/categorical_dqn/examples/train_eval_atari.py
+++ b/tf_agents/agents/categorical_dqn/examples/train_eval_atari.py
@@ -45,10 +45,6 @@ Additional flags are available such as `--replay_buffer_capacity` and
 `--n_step_update`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl import app

--- a/tf_agents/agents/ddpg/actor_rnn_network_test.py
+++ b/tf_agents/agents/ddpg/actor_rnn_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.agents.ddpg.actor_rnn_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/agents/ddpg/critic_rnn_network_test.py
+++ b/tf_agents/agents/ddpg/critic_rnn_network_test.py
@@ -15,9 +15,6 @@
 
 """Tests for tf_agents.agents.ddpg.critic_rnn_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing import parameterized
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/agents/ddpg/ddpg_agent.py
+++ b/tf_agents/agents/ddpg/ddpg_agent.py
@@ -19,11 +19,6 @@ Implements the Deep Deterministic Policy Gradient (DDPG) algorithm from
 "Continuous control with deep reinforcement learning" - Lilicrap et al.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Optional, Text
 

--- a/tf_agents/agents/ddpg/ddpg_agent_test.py
+++ b/tf_agents/agents/ddpg/ddpg_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.agents.ddpg.ddpg_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.agents.ddpg import ddpg_agent

--- a/tf_agents/agents/ddpg/examples/v1/train_eval.py
+++ b/tf_agents/agents/ddpg/examples/v1/train_eval.py
@@ -28,10 +28,6 @@ python tf_agents/agents/ddpg/examples/v1/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/ddpg/examples/v1/train_eval_rnn.py
+++ b/tf_agents/agents/ddpg/examples/v1/train_eval_rnn.py
@@ -28,10 +28,6 @@ python tf_agents/agents/ddpg/examples/v1/train_eval_rnn.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 import time

--- a/tf_agents/agents/ddpg/examples/v2/train_eval.py
+++ b/tf_agents/agents/ddpg/examples/v2/train_eval.py
@@ -28,10 +28,6 @@ python tf_agents/agents/ddpg/examples/v2/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/ddpg/examples/v2/train_eval_rnn.py
+++ b/tf_agents/agents/ddpg/examples/v2/train_eval_rnn.py
@@ -28,10 +28,6 @@ python tf_agents/agents/ddpg/examples/v2/train_eval_rnn.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 import time

--- a/tf_agents/agents/dqn/dqn_agent.py
+++ b/tf_agents/agents/dqn/dqn_agent.py
@@ -22,11 +22,6 @@ Implements the DQN algorithm from
   https://deepmind.com/research/dqn/
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Optional, Text
 

--- a/tf_agents/agents/dqn/dqn_agent_test.py
+++ b/tf_agents/agents/dqn/dqn_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for agents.dqn.dqn_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/agents/dqn/examples/v1/oog_train_eval.py
+++ b/tf_agents/agents/dqn/examples/v1/oog_train_eval.py
@@ -31,10 +31,6 @@ python tf_agents/agents/dqn/examples/v1/oog_train_eval.py \
   --alsologtostderr
 ```
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/dqn/examples/v1/train_eval_atari.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_atari.py
@@ -45,10 +45,6 @@ Additional flags are available such as `--replay_buffer_capacity` and
 `--n_step_update`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl import app

--- a/tf_agents/agents/dqn/examples/v1/train_eval_gym.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_gym.py
@@ -27,10 +27,6 @@ python tf_agents/agents/dqn/examples/v1/train_eval_gym.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/dqn/examples/v1/train_eval_rnn_gym.py
+++ b/tf_agents/agents/dqn/examples/v1/train_eval_rnn_gym.py
@@ -27,10 +27,6 @@ python tf_agents/agents/dqn/examples/v1/train_eval_rnn_gym.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/dqn/examples/v2/train_eval.py
+++ b/tf_agents/agents/dqn/examples/v2/train_eval.py
@@ -38,10 +38,6 @@ python tf_agents/agents/dqn/examples/v2/train_eval.py \
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/dqn/examples/v2/train_eval_test.py
+++ b/tf_agents/agents/dqn/examples/v2/train_eval_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.agents.dqn.examples.v2.train_eval."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import flags
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent.py
+++ b/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent.py
@@ -26,10 +26,6 @@ python tf_agents/agents/ppo/examples/v1/train_eval_clip_agent.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent_atari.py
+++ b/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent_atari.py
@@ -20,10 +20,6 @@ Launch train eval binary:
 For usage, see train_eval_clip_agent.py.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import app
 from absl import flags
 from absl import logging

--- a/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent_random_py_env.py
+++ b/tf_agents/agents/ppo/examples/v1/train_eval_clip_agent_random_py_env.py
@@ -20,10 +20,6 @@ Launch train eval binary:
 For usage, see train_eval_clip_agent.py.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import app
 from absl import flags
 from absl import logging

--- a/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
+++ b/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
@@ -26,10 +26,6 @@ python tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/ppo/ppo_agent.py
+++ b/tf_agents/agents/ppo/ppo_agent.py
@@ -56,11 +56,6 @@ only optimizing the minimum.
 Advantage is computed using Generalized Advantage Estimation (GAE):
 https://arxiv.org/abs/1506.02438
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Optional, Text, Tuple
 

--- a/tf_agents/agents/ppo/ppo_agent_test.py
+++ b/tf_agents/agents/ppo/ppo_agent_test.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Tests for TF Agents ppo_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import flags
 from absl.testing import parameterized
 from absl.testing.absltest import mock

--- a/tf_agents/agents/ppo/ppo_clip_agent.py
+++ b/tf_agents/agents/ppo/ppo_clip_agent.py
@@ -50,11 +50,6 @@ only optimizing the minimum.
 Advantage is computed using Generalized Advantage Estimation (GAE):
 https://arxiv.org/abs/1506.02438
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/agents/ppo/ppo_kl_penalty_agent.py
+++ b/tf_agents/agents/ppo/ppo_kl_penalty_agent.py
@@ -47,11 +47,6 @@ parameters unrelated to this particular PPO version, making it less error prone.
 Advantage is computed using Generalized Advantage Estimation (GAE):
 https://arxiv.org/abs/1506.02438
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/agents/ppo/ppo_policy.py
+++ b/tf_agents/agents/ppo/ppo_policy.py
@@ -15,11 +15,6 @@
 
 """An ActorPolicy that also returns policy_info needed for PPO training."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional
 
 import gin

--- a/tf_agents/agents/ppo/ppo_policy_test.py
+++ b/tf_agents/agents/ppo/ppo_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.policies.actor_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/agents/ppo/ppo_utils.py
+++ b/tf_agents/agents/ppo/ppo_utils.py
@@ -15,11 +15,6 @@
 
 """Utils functions for ppo_agent.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Sequence
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/agents/ppo/ppo_utils_test.py
+++ b/tf_agents/agents/ppo/ppo_utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for TF Agents ppo_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/agents/random/fixed_policy_agent.py
+++ b/tf_agents/agents/random/fixed_policy_agent.py
@@ -18,11 +18,6 @@
 An agent following one specific policy, without training.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Callable, Union, Optional, Text
 
 import gin

--- a/tf_agents/agents/random/random_agent.py
+++ b/tf_agents/agents/random/random_agent.py
@@ -19,11 +19,6 @@ An agent implementing a random policy without training. Useful as a baseline
 when comparing to other agents.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/agents/random/random_agent_test.py
+++ b/tf_agents/agents/random/random_agent_test.py
@@ -17,10 +17,6 @@
 """Tests for tf_agents.agents.random.random_agent."""
 
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import tensorflow.compat.v2 as tf

--- a/tf_agents/agents/reinforce/examples/v1/train_eval.py
+++ b/tf_agents/agents/reinforce/examples/v1/train_eval.py
@@ -27,10 +27,6 @@ python tf_agents/agents/reinforce/examples/v1/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/reinforce/examples/v2/train_eval.py
+++ b/tf_agents/agents/reinforce/examples/v2/train_eval.py
@@ -27,10 +27,6 @@ python tf_agents/agents/reinforce/examples/v2/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/reinforce/reinforce_agent.py
+++ b/tf_agents/agents/reinforce/reinforce_agent.py
@@ -18,11 +18,6 @@
 Implements the REINFORCE algorithm from (Williams, 1992):
 http://www-anw.cs.umass.edu/~barto/courses/cs687/williams92simple.pdf
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Callable, Optional, Text
 

--- a/tf_agents/agents/reinforce/reinforce_agent_test.py
+++ b/tf_agents/agents/reinforce/reinforce_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for TF Agents reinforce_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 from absl.testing.absltest import mock
 

--- a/tf_agents/agents/sac/examples/v1/train_eval.py
+++ b/tf_agents/agents/sac/examples/v1/train_eval.py
@@ -27,10 +27,6 @@ python tf_agents/agents/sac/examples/v1/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/sac/examples/v2/train_eval.py
+++ b/tf_agents/agents/sac/examples/v2/train_eval.py
@@ -30,10 +30,6 @@ python tf_agents/agents/sac/examples/v2/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/sac/examples/v2/train_eval_rnn.py
+++ b/tf_agents/agents/sac/examples/v2/train_eval_rnn.py
@@ -27,10 +27,6 @@ python tf_agents/agents/sac/examples/v2:train_eval_rnn --\
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 import time

--- a/tf_agents/agents/sac/sac_agent.py
+++ b/tf_agents/agents/sac/sac_agent.py
@@ -19,11 +19,6 @@
 Implements the Soft Actor-Critic (SAC) algorithm from
 "Soft Actor-Critic Algorithms and Applications" by Haarnoja et al (2019).
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Callable, Optional, Text
 

--- a/tf_agents/agents/sac/sac_agent_test.py
+++ b/tf_agents/agents/sac/sac_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.agents.sac.sac_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.agents.ddpg import critic_rnn_network

--- a/tf_agents/agents/sac/tanh_normal_projection_network.py
+++ b/tf_agents/agents/sac/tanh_normal_projection_network.py
@@ -18,11 +18,6 @@
 This network reproduces Soft Actor-Critic refererence implementation in:
 https://github.com/rail-berkeley/softlearning/
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Callable, Optional, Text
 
 import gin

--- a/tf_agents/agents/sac/tanh_normal_projection_network_test.py
+++ b/tf_agents/agents/sac/tanh_normal_projection_network_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.normal_projection_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 

--- a/tf_agents/agents/td3/examples/v1/train_eval.py
+++ b/tf_agents/agents/td3/examples/v1/train_eval.py
@@ -28,10 +28,6 @@ python tf_agents/agents/td3/examples/v1/train_eval.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/td3/examples/v1/train_eval_rnn.py
+++ b/tf_agents/agents/td3/examples/v1/train_eval_rnn.py
@@ -27,10 +27,6 @@ python tf_agents/agents/td3/examples/v1/train_eval_rnn.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 import time

--- a/tf_agents/agents/td3/examples/v2/train_eval.py
+++ b/tf_agents/agents/td3/examples/v2/train_eval.py
@@ -29,10 +29,6 @@ python tf_agents/agents/td3/examples/v2/train_eval.py \
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 

--- a/tf_agents/agents/td3/examples/v2/train_eval_rnn.py
+++ b/tf_agents/agents/td3/examples/v2/train_eval_rnn.py
@@ -27,10 +27,6 @@ python tf_agents/agents/td3/examples/v2/train_eval_rnn.py \
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 import time

--- a/tf_agents/agents/td3/td3_agent.py
+++ b/tf_agents/agents/td3/td3_agent.py
@@ -24,11 +24,6 @@ by Fujimoto et al.
 For the full paper, see https://arxiv.org/abs/1802.09477.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Optional, Text
 

--- a/tf_agents/agents/td3/td3_agent_test.py
+++ b/tf_agents/agents/td3/td3_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.agents.td3.td3_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.agents.td3 import td3_agent
 from tf_agents.networks import network

--- a/tf_agents/agents/tf_agent.py
+++ b/tf_agents/agents/tf_agent.py
@@ -15,11 +15,6 @@
 
 """TensorFlow RL Agent API."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 import collections
 from typing import Dict, Optional, Text

--- a/tf_agents/agents/tf_agent_test.py
+++ b/tf_agents/agents/tf_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for agents.tf_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/agents/constraints.py
+++ b/tf_agents/bandits/agents/constraints.py
@@ -15,10 +15,6 @@
 
 """An API for representing constraints."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 
 import functools

--- a/tf_agents/bandits/agents/constraints_test.py
+++ b/tf_agents/bandits/agents/constraints_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.constraints."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.agents import constraints

--- a/tf_agents/bandits/agents/dropout_thompson_sampling_agent.py
+++ b/tf_agents/bandits/agents/dropout_thompson_sampling_agent.py
@@ -19,10 +19,6 @@ Implements an agent based on a neural network that predicts arm rewards.
 The neural network internally uses dropout to approximate Thompson sampling.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/dropout_thompson_sampling_agent_test.py
+++ b/tf_agents/bandits/agents/dropout_thompson_sampling_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for dropout_thompson_sampling_agent.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/examples/v1/train_eval_drifting_linear.py
+++ b/tf_agents/bandits/agents/examples/v1/train_eval_drifting_linear.py
@@ -16,10 +16,6 @@
 """End-to-end test for bandits against a drifting linear environment.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import app
 from absl import flags

--- a/tf_agents/bandits/agents/examples/v1/train_eval_piecewise_linear.py
+++ b/tf_agents/bandits/agents/examples/v1/train_eval_piecewise_linear.py
@@ -16,10 +16,6 @@
 """End-to-end test for bandits against the piecewise linear environment.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import app
 from absl import flags

--- a/tf_agents/bandits/agents/examples/v1/train_eval_stationary_linear.py
+++ b/tf_agents/bandits/agents/examples/v1/train_eval_stationary_linear.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under stationary linear environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v1/train_eval_wheel.py
+++ b/tf_agents/bandits/agents/examples/v1/train_eval_wheel.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under the wheel bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v1/trainer.py
+++ b/tf_agents/bandits/agents/examples/v1/trainer.py
@@ -15,10 +15,6 @@
 
 r"""Generic TF1 trainer for TF-Agents bandits."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import time
 from absl import logging

--- a/tf_agents/bandits/agents/examples/v1/trainer_test.py
+++ b/tf_agents/bandits/agents/examples/v1/trainer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.examples.v1.trainer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import tempfile
 import unittest

--- a/tf_agents/bandits/agents/examples/v2/train_eval_covertype.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_covertype.py
@@ -23,10 +23,6 @@ The reward is 1 if the right class was chosen, 0 otherwise.
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_dqn.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_dqn.py
@@ -19,10 +19,6 @@ Note: The training samples are *not* drawn at random from the replay buffer.
 Hence, this setup is not ideal for DQN.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_drifting_linear.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_drifting_linear.py
@@ -16,10 +16,6 @@
 """End-to-end test for bandits against a drifting linear environment.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import app
 from absl import flags

--- a/tf_agents/bandits/agents/examples/v2/train_eval_mushroom.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_mushroom.py
@@ -16,10 +16,6 @@
 """End-to-end test for bandits against a mushroom environment.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_per_arm_stationary_linear.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_per_arm_stationary_linear.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under stationary linear environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_piecewise_linear.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_piecewise_linear.py
@@ -16,10 +16,6 @@
 """End-to-end test for bandits against the piecewise linear environment.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import app
 from absl import flags

--- a/tf_agents/bandits/agents/examples/v2/train_eval_sparse_features.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_sparse_features.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under sparse feature environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import app
 from absl import flags

--- a/tf_agents/bandits/agents/examples/v2/train_eval_stationary_linear.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_stationary_linear.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under stationary linear environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_structured_linear.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_structured_linear.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under structured linear environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/train_eval_wheel.py
+++ b/tf_agents/bandits/agents/examples/v2/train_eval_wheel.py
@@ -15,10 +15,6 @@
 
 """End-to-end test for bandit training under the wheel bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import os
 from absl import app

--- a/tf_agents/bandits/agents/examples/v2/trainer.py
+++ b/tf_agents/bandits/agents/examples/v2/trainer.py
@@ -15,10 +15,6 @@
 
 r"""Generic TF-Agents training function for bandits."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import logging
 

--- a/tf_agents/bandits/agents/examples/v2/trainer_test.py
+++ b/tf_agents/bandits/agents/examples/v2/trainer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.examples.v2.trainer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import tempfile
 

--- a/tf_agents/bandits/agents/exp3_agent.py
+++ b/tf_agents/bandits/agents/exp3_agent.py
@@ -22,10 +22,6 @@ Implementation based on
   https://tor-lattimore.com/downloads/book/book.pdf
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/exp3_agent_test.py
+++ b/tf_agents/bandits/agents/exp3_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.exp3_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/agents/exp3_mixture_agent.py
+++ b/tf_agents/bandits/agents/exp3_mixture_agent.py
@@ -19,10 +19,6 @@ For a reference on EXP3, see `Bandit Algorithms` by Tor Lattimore and Csaba
 Szepesvari (https://tor-lattimore.com/downloads/book/book.pdf).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/agents/exp3_mixture_agent_test.py
+++ b/tf_agents/bandits/agents/exp3_mixture_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.exp3_mixture_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf

--- a/tf_agents/bandits/agents/greedy_reward_prediction_agent.py
+++ b/tf_agents/bandits/agents/greedy_reward_prediction_agent.py
@@ -15,10 +15,6 @@
 
 """An agent that uses and trains a greedy reward prediction policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import logging
 
 import gin

--- a/tf_agents/bandits/agents/greedy_reward_prediction_agent_test.py
+++ b/tf_agents/bandits/agents/greedy_reward_prediction_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for greedy_reward_prediction_agent.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/lin_ucb_agent.py
+++ b/tf_agents/bandits/agents/lin_ucb_agent.py
@@ -21,10 +21,6 @@
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/linear_bandit_agent.py
+++ b/tf_agents/bandits/agents/linear_bandit_agent.py
@@ -18,10 +18,6 @@
 LinUCB and Linear Thompson Sampling agents are subclasses of this agent.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from enum import Enum
 
 import gin

--- a/tf_agents/bandits/agents/linear_bandit_agent_test.py
+++ b/tf_agents/bandits/agents/linear_bandit_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.linear_bandit_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl.testing import parameterized

--- a/tf_agents/bandits/agents/linear_thompson_sampling_agent.py
+++ b/tf_agents/bandits/agents/linear_thompson_sampling_agent.py
@@ -23,10 +23,6 @@
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/loss_utils.py
+++ b/tf_agents/bandits/agents/loss_utils.py
@@ -15,9 +15,6 @@
 
 """Loss utility code."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 

--- a/tf_agents/bandits/agents/loss_utils_test.py
+++ b/tf_agents/bandits/agents/loss_utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.loss_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.agents import loss_utils

--- a/tf_agents/bandits/agents/mixture_agent.py
+++ b/tf_agents/bandits/agents/mixture_agent.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """An agent that mixes a list of agents with a constant mixture distribution."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/agents/mixture_agent_test.py
+++ b/tf_agents/bandits/agents/mixture_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.mixture_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf

--- a/tf_agents/bandits/agents/neural_epsilon_greedy_agent.py
+++ b/tf_agents/bandits/agents/neural_epsilon_greedy_agent.py
@@ -20,10 +20,6 @@ The policy adds epsilon greedy exploration.
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/neural_epsilon_greedy_agent_test.py
+++ b/tf_agents/bandits/agents/neural_epsilon_greedy_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for neural_epsilon_greedy_agent.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.bandits.agents import neural_epsilon_greedy_agent

--- a/tf_agents/bandits/agents/neural_linucb_agent.py
+++ b/tf_agents/bandits/agents/neural_linucb_agent.py
@@ -27,10 +27,6 @@
   Networks for Thompson Sampling`, ICLR 2018.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/agents/neural_linucb_agent_test.py
+++ b/tf_agents/bandits/agents/neural_linucb_agent_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.neural_linucb_agent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl.testing import parameterized

--- a/tf_agents/bandits/agents/static_mixture_agent.py
+++ b/tf_agents/bandits/agents/static_mixture_agent.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """An agent that mixes a list of agents with a constant mixture distribution."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 
 from tf_agents.bandits.agents import mixture_agent

--- a/tf_agents/bandits/agents/utils.py
+++ b/tf_agents/bandits/agents/utils.py
@@ -15,10 +15,6 @@
 
 """Common utility code and linear algebra functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/agents/utils_test.py
+++ b/tf_agents/bandits/agents/utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/drivers/driver_utils.py
+++ b/tf_agents/bandits/drivers/driver_utils.py
@@ -15,10 +15,6 @@
 
 """Driver utilities for use with bandit policies and environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.trajectories import trajectory
 

--- a/tf_agents/bandits/environments/bandit_py_environment.py
+++ b/tf_agents/bandits/environments/bandit_py_environment.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Base class for Bandit Python environments."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import numpy as np
 

--- a/tf_agents/bandits/environments/bandit_tf_environment.py
+++ b/tf_agents/bandits/environments/bandit_tf_environment.py
@@ -15,10 +15,6 @@
 
 """Base class for bandit environments implemented in TensorFlow."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import six
 

--- a/tf_agents/bandits/environments/bandit_tf_environment_test.py
+++ b/tf_agents/bandits/environments/bandit_tf_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.bandit_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/environments/bernoulli_action_mask_tf_environment.py
+++ b/tf_agents/bandits/environments/bernoulli_action_mask_tf_environment.py
@@ -36,10 +36,6 @@ Usage:
  '''
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/environments/bernoulli_action_mask_tf_environment_test.py
+++ b/tf_agents/bandits/environments/bernoulli_action_mask_tf_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.bernoulli_action_mask_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/environments/bernoulli_py_environment_test.py
+++ b/tf_agents/bandits/environments/bernoulli_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Bernoulli Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.bandits.environments import bernoulli_py_environment

--- a/tf_agents/bandits/environments/classification_environment.py
+++ b/tf_agents/bandits/environments/classification_environment.py
@@ -15,10 +15,6 @@
 
 """An environment based on an arbitrary classification problem."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/environments/classification_environment_test.py
+++ b/tf_agents/bandits/environments/classification_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.classification_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 from absl.testing.absltest import mock
 import numpy as np

--- a/tf_agents/bandits/environments/drifting_linear_environment.py
+++ b/tf_agents/bandits/environments/drifting_linear_environment.py
@@ -15,10 +15,6 @@
 
 """Bandit drifting linear environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/environments/drifting_linear_environment_test.py
+++ b/tf_agents/bandits/environments/drifting_linear_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.drifting_linear_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/environments/environment_utilities.py
+++ b/tf_agents/bandits/environments/environment_utilities.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Utility functions for configuring environments with Gin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import gin
 import numpy as np

--- a/tf_agents/bandits/environments/mushroom_environment_utilities.py
+++ b/tf_agents/bandits/environments/mushroom_environment_utilities.py
@@ -21,10 +21,6 @@ other columns represent features. All features, as well as the label, are string
 features that will be used for one-hot embeddings.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 

--- a/tf_agents/bandits/environments/mushroom_environment_utilities_test.py
+++ b/tf_agents/bandits/environments/mushroom_environment_utilities_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.mushroom_environment_utilities."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/environments/non_stationary_stochastic_environment.py
+++ b/tf_agents/bandits/environments/non_stationary_stochastic_environment.py
@@ -15,10 +15,6 @@
 
 """Bandit environment that returns random observations and rewards."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import gin
 import six

--- a/tf_agents/bandits/environments/non_stationary_stochastic_environment_test.py
+++ b/tf_agents/bandits/environments/non_stationary_stochastic_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.bandit_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 

--- a/tf_agents/bandits/environments/piecewise_bernoulli_py_environment_test.py
+++ b/tf_agents/bandits/environments/piecewise_bernoulli_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Bernoulli Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/environments/piecewise_stochastic_environment.py
+++ b/tf_agents/bandits/environments/piecewise_stochastic_environment.py
@@ -15,10 +15,6 @@
 
 """Bandit piecewise linear stationary environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/environments/piecewise_stochastic_environment_test.py
+++ b/tf_agents/bandits/environments/piecewise_stochastic_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.bandit_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/environments/random_bandit_environment.py
+++ b/tf_agents/bandits/environments/random_bandit_environment.py
@@ -15,10 +15,6 @@
 
 """Bandit environment that returns random observations and rewards."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.environments import bandit_tf_environment as bte
 from tf_agents.specs import tensor_spec

--- a/tf_agents/bandits/environments/random_bandit_environment_test.py
+++ b/tf_agents/bandits/environments/random_bandit_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.environments.bandit_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/environments/stationary_stochastic_per_arm_py_environment_test.py
+++ b/tf_agents/bandits/environments/stationary_stochastic_per_arm_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Stationary Stochastic Per-Arm Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.environments import stationary_stochastic_per_arm_py_environment as sspe

--- a/tf_agents/bandits/environments/stationary_stochastic_py_environment_test.py
+++ b/tf_agents/bandits/environments/stationary_stochastic_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Stationary Stochastic Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.environments import stationary_stochastic_py_environment as sspe

--- a/tf_agents/bandits/environments/stationary_stochastic_structured_py_environment.py
+++ b/tf_agents/bandits/environments/stationary_stochastic_structured_py_environment.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Stationary Stochastic Python Bandit environment with structured features."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 import tensorflow as tf

--- a/tf_agents/bandits/environments/stationary_stochastic_structured_py_environment_test.py
+++ b/tf_agents/bandits/environments/stationary_stochastic_structured_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Stationary Stochastic Structured Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.environments import stationary_stochastic_structured_py_environment as ssspe

--- a/tf_agents/bandits/environments/wheel_py_environment.py
+++ b/tf_agents/bandits/environments/wheel_py_environment.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 """Class implementation of Python Wheel Bandit environment."""
-from __future__ import absolute_import
-
 import gin
 import numpy as np
 from tf_agents.bandits.environments import bandit_py_environment

--- a/tf_agents/bandits/environments/wheel_py_environment_test.py
+++ b/tf_agents/bandits/environments/wheel_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the Wheel Bandit environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/metrics/tf_metrics.py
+++ b/tf_agents/bandits/metrics/tf_metrics.py
@@ -15,10 +15,6 @@
 
 """TF metrics for Bandits algorithms."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/metrics/tf_metrics_test.py
+++ b/tf_agents/bandits/metrics/tf_metrics_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Test for tf_agents.bandits.metrics.tf_metrics."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.bandits.agents import constraints

--- a/tf_agents/bandits/networks/global_and_arm_feature_network.py
+++ b/tf_agents/bandits/networks/global_and_arm_feature_network.py
@@ -15,10 +15,6 @@
 
 """Networks that take as input global and per-arm features, and output rewards."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/bandits/networks/global_and_arm_feature_network_test.py
+++ b/tf_agents/bandits/networks/global_and_arm_feature_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.networks.global_and_arm_feature_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/networks/heteroscedastic_q_network.py
+++ b/tf_agents/bandits/networks/heteroscedastic_q_network.py
@@ -15,10 +15,6 @@
 
 """Network Outputting Expected Value and Variance of Rewards."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 
 import gin

--- a/tf_agents/bandits/networks/heteroscedastic_q_network_test.py
+++ b/tf_agents/bandits/networks/heteroscedastic_q_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.network.heteroscedastic_q_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import math
 
 import gin

--- a/tf_agents/bandits/policies/categorical_policy.py
+++ b/tf_agents/bandits/policies/categorical_policy.py
@@ -15,10 +15,6 @@
 
 """Policy that chooses actions based on a categorical distribution."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 from tf_agents.policies import tf_policy

--- a/tf_agents/bandits/policies/categorical_policy_test.py
+++ b/tf_agents/bandits/policies/categorical_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.policies.categorical_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/greedy_reward_prediction_policy.py
+++ b/tf_agents/bandits/policies/greedy_reward_prediction_policy.py
@@ -15,10 +15,6 @@
 
 """Policy for greedy reward prediction."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/policies/greedy_reward_prediction_policy_test.py
+++ b/tf_agents/bandits/policies/greedy_reward_prediction_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Test for greedy_reward_prediction_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/lin_ucb_policy.py
+++ b/tf_agents/bandits/policies/lin_ucb_policy.py
@@ -15,10 +15,6 @@
 
 """Linear UCB Policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from tf_agents.bandits.policies import linear_bandit_policy as lin_policy
 
 

--- a/tf_agents/bandits/policies/linalg.py
+++ b/tf_agents/bandits/policies/linalg.py
@@ -15,10 +15,6 @@
 
 """Utility code for linear algebra functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import common
 

--- a/tf_agents/bandits/policies/linalg_test.py
+++ b/tf_agents/bandits/policies/linalg_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.agents.linalg."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/linear_bandit_policy.py
+++ b/tf_agents/bandits/policies/linear_bandit_policy.py
@@ -35,10 +35,6 @@ Shipra Agrawal, Navin Goyal, ICML 2013
 (http://proceedings.mlr.press/v28/agrawal13-supp.pdf).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from enum import Enum
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/linear_bandit_policy_test.py
+++ b/tf_agents/bandits/policies/linear_bandit_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.bandits.policies.linear_bandit_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/linear_thompson_sampling_policy.py
+++ b/tf_agents/bandits/policies/linear_thompson_sampling_policy.py
@@ -15,10 +15,6 @@
 
 """Linear Thompson Sampling Policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from tf_agents.bandits.policies import linear_bandit_policy as lin_policy
 
 

--- a/tf_agents/bandits/policies/mixture_policy.py
+++ b/tf_agents/bandits/policies/mixture_policy.py
@@ -20,10 +20,6 @@ them for every observation. The distribution is defined by the
 `mixture_distribution`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/policies/mixture_policy_test.py
+++ b/tf_agents/bandits/policies/mixture_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.policies.mixture_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import tensorflow as tf
 import tensorflow_probability as tfp

--- a/tf_agents/bandits/policies/neural_linucb_policy.py
+++ b/tf_agents/bandits/policies/neural_linucb_policy.py
@@ -15,10 +15,6 @@
 
 """Neural + LinUCB Policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 from tf_agents.bandits.policies import linalg

--- a/tf_agents/bandits/policies/neural_linucb_policy_test.py
+++ b/tf_agents/bandits/policies/neural_linucb_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.bandits.policies.neural_linucb_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/policies/policy_utilities.py
+++ b/tf_agents/bandits/policies/policy_utilities.py
@@ -15,10 +15,6 @@
 
 """Utilities for bandit policies."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 
 from absl import logging

--- a/tf_agents/bandits/policies/policy_utilities_test.py
+++ b/tf_agents/bandits/policies/policy_utilities_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.bandits.policies.policy_utilities."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/bandits/specs/utils.py
+++ b/tf_agents/bandits/specs/utils.py
@@ -15,10 +15,6 @@
 
 """Bandit related tensor spec utilities."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 from absl import logging
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/benchmark/distribution_strategy_utils.py
+++ b/tf_agents/benchmark/distribution_strategy_utils.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Helper functions for running models in a distributed setting."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from six.moves import range
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/benchmark/dqn_benchmark_test.py
+++ b/tf_agents/benchmark/dqn_benchmark_test.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Benchmarks for DqnAgent."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/tf_agents/benchmark/utils.py
+++ b/tf_agents/benchmark/utils.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Utilities for running benchmarks."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import time
 
 import numpy as np

--- a/tf_agents/distributions/gumbel_softmax.py
+++ b/tf_agents/distributions/gumbel_softmax.py
@@ -15,10 +15,6 @@
 
 """Gumbel_Softmax distribution classes."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
 

--- a/tf_agents/distributions/gumbel_softmax_test.py
+++ b/tf_agents/distributions/gumbel_softmax_test.py
@@ -15,11 +15,6 @@
 
 """Tests for tf_agents.distributions.gumbel_softmax."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.distributions import gumbel_softmax

--- a/tf_agents/distributions/reparameterized_sampling.py
+++ b/tf_agents/distributions/reparameterized_sampling.py
@@ -17,10 +17,6 @@
 """Helper function to do reparameterized sampling if the distributions supports it.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow_probability as tfp
 
 from tf_agents.distributions import gumbel_softmax

--- a/tf_agents/distributions/tanh_bijector_stable.py
+++ b/tf_agents/distributions/tanh_bijector_stable.py
@@ -15,10 +15,6 @@
 
 """Tanh bijector."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tensorflow_probability.python.bijectors import bijector
 

--- a/tf_agents/distributions/utils.py
+++ b/tf_agents/distributions/utils.py
@@ -15,10 +15,6 @@
 
 """Utilities related to distributions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 from tf_agents.distributions import tanh_bijector_stable

--- a/tf_agents/distributions/utils_test.py
+++ b/tf_agents/distributions/utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.distributions.utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 from tf_agents.distributions import utils

--- a/tf_agents/drivers/driver.py
+++ b/tf_agents/drivers/driver.py
@@ -15,10 +15,6 @@
 
 """Base class for drivers that takes steps in an environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import six
 

--- a/tf_agents/drivers/dynamic_episode_driver.py
+++ b/tf_agents/drivers/dynamic_episode_driver.py
@@ -15,10 +15,6 @@
 
 """A Driver that takes N episodes in the environment using a tf.while_loop."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/dynamic_episode_driver_test.py
+++ b/tf_agents/drivers/dynamic_episode_driver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.drivers.dynamic_episode_driver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/dynamic_step_driver.py
+++ b/tf_agents/drivers/dynamic_step_driver.py
@@ -15,10 +15,6 @@
 
 """A Driver that takes N steps in the environment using a tf.while_loop."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/dynamic_step_driver_test.py
+++ b/tf_agents/drivers/dynamic_step_driver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.drivers.dynamic_step_driver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/py_driver.py
+++ b/tf_agents/drivers/py_driver.py
@@ -15,11 +15,6 @@
 
 """A Driver that steps a python environment using a python policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import numpy as np
 from tf_agents.drivers import driver
 from tf_agents.environments import py_environment

--- a/tf_agents/drivers/py_driver_test.py
+++ b/tf_agents/drivers/py_driver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.drivers.py_driver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import numpy as np

--- a/tf_agents/drivers/test_utils.py
+++ b/tf_agents/drivers/test_utils.py
@@ -15,10 +15,6 @@
 
 """Common mock env and policy for testing drivers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/tf_driver.py
+++ b/tf_agents/drivers/tf_driver.py
@@ -15,11 +15,6 @@
 
 """A Driver that steps a TF environment using a TF policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/drivers/tf_driver_test.py
+++ b/tf_agents/drivers/tf_driver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.drivers.tf_driver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import numpy as np

--- a/tf_agents/environments/atari_preprocessing.py
+++ b/tf_agents/environments/atari_preprocessing.py
@@ -25,11 +25,6 @@ This includes:
   . Resizing the image before it is provided to the agent.
 
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import gin
 import gym
 from gym import core as gym_core

--- a/tf_agents/environments/atari_preprocessing_test.py
+++ b/tf_agents/environments/atari_preprocessing_test.py
@@ -21,10 +21,6 @@ https://github.com/google/dopamine/blob/master/tests/dopamine/discrete_domains/a
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from gym import core as gym_core
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/environments/atari_wrappers.py
+++ b/tf_agents/environments/atari_wrappers.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Wrappers for Atari Environments."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Any, Text
 

--- a/tf_agents/environments/atari_wrappers_test.py
+++ b/tf_agents/environments/atari_wrappers_test.py
@@ -15,9 +15,6 @@
 
 """Tests for environments.atari_wrappers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing.absltest import mock
 
 from tf_agents.environments import atari_wrappers

--- a/tf_agents/environments/batched_py_environment.py
+++ b/tf_agents/environments/batched_py_environment.py
@@ -15,11 +15,6 @@
 
 """Treat multiple non-batch environments as a single batch environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 # pylint: disable=line-too-long
 # multiprocessing.dummy provides a pure *multithreaded* threadpool that works
 # in both python2 and python3 (concurrent.futures isn't available in python2).

--- a/tf_agents/environments/batched_py_environment_test.py
+++ b/tf_agents/environments/batched_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the parallel environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import functools
 

--- a/tf_agents/environments/dm_control_wrapper.py
+++ b/tf_agents/environments/dm_control_wrapper.py
@@ -15,10 +15,6 @@
 
 """Wrapper providing a PyEnvironmentBase adapter for Gym environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/environments/dm_control_wrapper_test.py
+++ b/tf_agents/environments/dm_control_wrapper_test.py
@@ -15,9 +15,6 @@
 
 """Tests for tf_agents.google.environments.dm_control_wrapper."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 
 from tf_agents.environments import suite_dm_control

--- a/tf_agents/environments/examples/masked_cartpole.py
+++ b/tf_agents/environments/examples/masked_cartpole.py
@@ -18,10 +18,6 @@
 See agents/dqn/examples/train_eval_gym_rnn.py for usage.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gym
 from gym.envs.classic_control import cartpole
 from gym.envs.registration import register

--- a/tf_agents/environments/gym_wrapper.py
+++ b/tf_agents/environments/gym_wrapper.py
@@ -15,11 +15,6 @@
 
 """Wrapper providing a PyEnvironmentBase adapter for Gym environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import Any, Dict, Optional, Text
 

--- a/tf_agents/environments/gym_wrapper_test.py
+++ b/tf_agents/environments/gym_wrapper_test.py
@@ -15,10 +15,6 @@
 
 """Tests for environments.gym_wrapper."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import math
 from absl.testing.absltest import mock
 import gym

--- a/tf_agents/environments/parallel_py_environment.py
+++ b/tf_agents/environments/parallel_py_environment.py
@@ -15,11 +15,6 @@
 
 """Runs multiple environments in parallel processes and steps them in batch."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import atexit
 import sys
 import traceback

--- a/tf_agents/environments/parallel_py_environment_test.py
+++ b/tf_agents/environments/parallel_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for the parallel_py_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import functools
 import time

--- a/tf_agents/environments/py_environment.py
+++ b/tf_agents/environments/py_environment.py
@@ -19,11 +19,6 @@ Adapted from the Deepmind's Environment API as seen in:
   https://github.com/deepmind/dm_control
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 from typing import Any, Optional, Text
 

--- a/tf_agents/environments/py_environment_test.py
+++ b/tf_agents/environments/py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.environments.py_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/environments/random_py_environment.py
+++ b/tf_agents/environments/random_py_environment.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Environment implementation that generates random observations."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Callable, Optional, Sequence, Text
 import numpy as np
 

--- a/tf_agents/environments/random_py_environment_test.py
+++ b/tf_agents/environments/random_py_environment_test.py
@@ -15,9 +15,6 @@
 
 """Tests for utils.random_py_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
 

--- a/tf_agents/environments/random_tf_environment.py
+++ b/tf_agents/environments/random_tf_environment.py
@@ -15,10 +15,6 @@
 
 """Utility environment that creates random observations."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.environments import tf_environment

--- a/tf_agents/environments/random_tf_environment_test.py
+++ b/tf_agents/environments/random_tf_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.environments.random_tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/environments/suite_atari.py
+++ b/tf_agents/environments/suite_atari.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Suite for loading Atari Gym environments."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Dict, Optional, Sequence, Text
 
 import atari_py  # pylint: disable=unused-import

--- a/tf_agents/environments/suite_atari_test.py
+++ b/tf_agents/environments/suite_atari_test.py
@@ -15,10 +15,6 @@
 
 """Tests for third_party.py.tf_agents.environments.suite_atari."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import flags
 import numpy as np
 

--- a/tf_agents/environments/suite_bsuite.py
+++ b/tf_agents/environments/suite_bsuite.py
@@ -20,11 +20,6 @@ https://github.com/deepmind/bsuite/
 
 Follow https://github.com/deepmind/bsuite#getting-started to install bsuite
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 import gin
 from tf_agents.environments import py_environment

--- a/tf_agents/environments/suite_bsuite_test.py
+++ b/tf_agents/environments/suite_bsuite_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.environments.suite_bsuite."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 
 from tf_agents.environments import py_environment

--- a/tf_agents/environments/suite_dm_control.py
+++ b/tf_agents/environments/suite_dm_control.py
@@ -20,11 +20,6 @@ Follow these instructions to install it:
 https://github.com/deepmind/dm_control#installation-and-requirements
 
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Sequence, Text
 
 import gin

--- a/tf_agents/environments/suite_dm_control_test.py
+++ b/tf_agents/environments/suite_dm_control_test.py
@@ -15,9 +15,6 @@
 
 """Tests for dm_control_wrapper."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 
 from tf_agents.environments import py_environment

--- a/tf_agents/environments/suite_gym.py
+++ b/tf_agents/environments/suite_gym.py
@@ -22,11 +22,6 @@ agent behaviour. This prevents us from setting the appropriate discount value
 for the final step of an episode. To prevent that we extract the step limit
 from the environment specs and utilize our TimeLimit wrapper.
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Callable, Dict, Optional, Sequence, Text
 
 import gin

--- a/tf_agents/environments/suite_gym_test.py
+++ b/tf_agents/environments/suite_gym_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.environments.suite_gym."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 
 import gin

--- a/tf_agents/environments/suite_mujoco.py
+++ b/tf_agents/environments/suite_mujoco.py
@@ -22,11 +22,6 @@ Follow the instructions at:
 https://github.com/openai/mujoco-py
 
 """
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Dict, Optional, Sequence, Text
 
 import gin

--- a/tf_agents/environments/suite_mujoco_test.py
+++ b/tf_agents/environments/suite_mujoco_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.environments.suite_mujoco."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 

--- a/tf_agents/environments/suite_pybullet_test.py
+++ b/tf_agents/environments/suite_pybullet_test.py
@@ -15,10 +15,6 @@
 
 """Tests tf_agents.environments.suite_pybullet."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 
 from tf_agents.environments import py_environment

--- a/tf_agents/environments/test_envs.py
+++ b/tf_agents/environments/test_envs.py
@@ -16,11 +16,6 @@
 # Lint as: python3
 """Collection of simple environments useful for testing."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import gin
 import numpy as np
 

--- a/tf_agents/environments/test_envs_test.py
+++ b/tf_agents/environments/test_envs_test.py
@@ -16,10 +16,6 @@
 # Lint as: python3
 """Tests for tf_agents.environments.test_envs."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from tf_agents.environments import test_envs
 from tf_agents.environments import utils as env_utils
 from tf_agents.utils import test_utils

--- a/tf_agents/environments/tf_environment.py
+++ b/tf_agents/environments/tf_environment.py
@@ -24,10 +24,6 @@ environmet if needed. Only needed in graph mode.
 - The step(action) method applies the action and returns the new time_step.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import six
 

--- a/tf_agents/environments/tf_environment_test.py
+++ b/tf_agents/environments/tf_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for environments.tf_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents import specs

--- a/tf_agents/environments/tf_py_environment.py
+++ b/tf_agents/environments/tf_py_environment.py
@@ -15,10 +15,6 @@
 
 """Wrapper for PyEnvironments into TFEnvironments."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import contextlib
 from multiprocessing import pool
 import threading

--- a/tf_agents/environments/tf_py_environment_test.py
+++ b/tf_agents/environments/tf_py_environment_test.py
@@ -15,10 +15,6 @@
 
 """Tests for reinforment_learning.environment.tf_py_environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import threading
 
 from absl.testing import parameterized

--- a/tf_agents/environments/tf_wrappers.py
+++ b/tf_agents/environments/tf_wrappers.py
@@ -18,10 +18,6 @@
 Use tf_agents.environments.wrapper for PyEnvironments.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.environments import tf_environment

--- a/tf_agents/environments/tf_wrappers_test.py
+++ b/tf_agents/environments/tf_wrappers_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.environments.tf_wrappers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing.absltest import mock
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/environments/trajectory_replay.py
+++ b/tf_agents/environments/trajectory_replay.py
@@ -15,10 +15,6 @@
 
 """A Driver-like object that replays Trajectories."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/environments/trajectory_replay_test.py
+++ b/tf_agents/environments/trajectory_replay_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.drivers.trajectory_replay."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/environments/utils.py
+++ b/tf_agents/environments/utils.py
@@ -15,11 +15,6 @@
 
 """Common utilities for TF-Agents Environments."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Union
 
 from tf_agents.environments import py_environment

--- a/tf_agents/environments/utils_test.py
+++ b/tf_agents/environments/utils_test.py
@@ -15,9 +15,6 @@
 
 """Tests for tf_agents.environments.utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing.absltest import mock
 import numpy as np
 from tf_agents.environments import utils

--- a/tf_agents/environments/wrappers.py
+++ b/tf_agents/environments/wrappers.py
@@ -19,11 +19,6 @@ Wrappers in this module can be chained to change the overall behaviour of an
 environment in common ways.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 import collections
 import cProfile

--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Test for tf_agents.environments.wrappers."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 import cProfile
 import math

--- a/tf_agents/eval/metric_utils.py
+++ b/tf_agents/eval/metric_utils.py
@@ -15,10 +15,6 @@
 
 """Utils for Metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 from absl import logging
 import gin

--- a/tf_agents/eval/metric_utils_test.py
+++ b/tf_agents/eval/metric_utils_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.eval.metric_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/keras_layers/bias_layer.py
+++ b/tf_agents/keras_layers/bias_layer.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Keras layer mirroring tf.contrib.layers.bias_add."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 

--- a/tf_agents/keras_layers/bias_layer_test.py
+++ b/tf_agents/keras_layers/bias_layer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.keras_layers.bias_layer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/keras_layers/dynamic_unroll_layer.py
+++ b/tf_agents/keras_layers/dynamic_unroll_layer.py
@@ -32,10 +32,6 @@ episode tensors in the form of `inputs`.
 See the unit tests in `rnn_utils_test.py` for more details.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.utils import common

--- a/tf_agents/keras_layers/dynamic_unroll_layer_test.py
+++ b/tf_agents/keras_layers/dynamic_unroll_layer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.keras_layers.dynamic_unroll_layer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import numpy as np

--- a/tf_agents/keras_layers/sequential_layer.py
+++ b/tf_agents/keras_layers/sequential_layer.py
@@ -15,10 +15,6 @@
 
 """Keras layer to replace the Sequential Model object."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/keras_layers/sequential_layer_test.py
+++ b/tf_agents/keras_layers/sequential_layer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.keras_layers.sequential_layer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl import flags

--- a/tf_agents/metrics/batched_py_metric.py
+++ b/tf_agents/metrics/batched_py_metric.py
@@ -15,11 +15,6 @@
 
 """A python metric that can be called with batches of trajectories."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import numpy as np
 from tf_agents.metrics import py_metric
 from tf_agents.trajectories import trajectory as traj

--- a/tf_agents/metrics/batched_py_metric_test.py
+++ b/tf_agents/metrics/batched_py_metric_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.metrics.batched_py_metric."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.metrics import batched_py_metric
 from tf_agents.metrics import py_metrics

--- a/tf_agents/metrics/metric_equality_test.py
+++ b/tf_agents/metrics/metric_equality_test.py
@@ -16,10 +16,6 @@
 # Lint as: python3
 """Tests for tf_agents.metrics.metric_equality."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 from six.moves import range
 from six.moves import zip

--- a/tf_agents/metrics/py_metric.py
+++ b/tf_agents/metrics/py_metric.py
@@ -15,11 +15,6 @@
 
 """Base class for Python metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 from typing import Any, Optional, Sequence, Text, Union
 

--- a/tf_agents/metrics/py_metric_test.py
+++ b/tf_agents/metrics/py_metric_test.py
@@ -16,10 +16,6 @@
 """Tests for tf_agents.metrics.py_metric."""
 
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import tempfile
 

--- a/tf_agents/metrics/py_metrics.py
+++ b/tf_agents/metrics/py_metrics.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Implementation of various python metrics."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 
 import gin

--- a/tf_agents/metrics/py_metrics_test.py
+++ b/tf_agents/metrics/py_metrics_test.py
@@ -16,10 +16,6 @@
 """Tests for tf_agents.metrics.py_metrics."""
 
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/metrics/tf_metric.py
+++ b/tf_agents/metrics/tf_metric.py
@@ -15,10 +15,6 @@
 
 """Base class for TensorFlow metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import common
 

--- a/tf_agents/metrics/tf_metrics.py
+++ b/tf_agents/metrics/tf_metrics.py
@@ -15,10 +15,6 @@
 
 """TF metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import logging
 import gin
 import numpy as np

--- a/tf_agents/metrics/tf_metrics_test.py
+++ b/tf_agents/metrics/tf_metrics_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Test for tf_agents.train.tf_metrics."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.metrics import tf_metrics

--- a/tf_agents/metrics/tf_py_metric.py
+++ b/tf_agents/metrics/tf_py_metric.py
@@ -15,10 +15,6 @@
 
 """Wraps a python metric as a TF metric."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import contextlib
 import threading
 

--- a/tf_agents/metrics/tf_py_metric_test.py
+++ b/tf_agents/metrics/tf_py_metric_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.metrics.tf_py_metric."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/actor_distribution_network.py
+++ b/tf_agents/networks/actor_distribution_network.py
@@ -15,10 +15,6 @@
 
 """Sample Keras actor network that generates distributions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/actor_distribution_network_test.py
+++ b/tf_agents/networks/actor_distribution_network_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.actor_distribution_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/actor_distribution_rnn_network.py
+++ b/tf_agents/networks/actor_distribution_rnn_network.py
@@ -15,11 +15,6 @@
 
 """Sample Keras actor network  with LSTM cells that generates distributions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 import gin
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/actor_distribution_rnn_network_test.py
+++ b/tf_agents/networks/actor_distribution_rnn_network_test.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.actor_distribution_rnn_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing import parameterized
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/categorical_projection_network.py
+++ b/tf_agents/networks/categorical_projection_network.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Project inputs to a categorical distribution object."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/categorical_projection_network_test.py
+++ b/tf_agents/networks/categorical_projection_network_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.categorical_projection_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 

--- a/tf_agents/networks/categorical_q_network.py
+++ b/tf_agents/networks/categorical_q_network.py
@@ -19,10 +19,6 @@ See "A Distributional Perspective on Reinforcement Learning" by Bellemare,
 Dabney, and Munos (2017). https://arxiv.org/abs/1707.06887
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/categorical_q_network_test.py
+++ b/tf_agents/networks/categorical_q_network_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.categorical_q_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/encoding_network.py
+++ b/tf_agents/networks/encoding_network.py
@@ -25,10 +25,6 @@ Implements a network that will generate the following layers:
   [optional]: Dense  # fc_layer_params
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import logging
 import gin
 from six.moves import zip

--- a/tf_agents/networks/encoding_network_test.py
+++ b/tf_agents/networks/encoding_network_test.py
@@ -16,10 +16,6 @@
 # Lint as: python2, python3
 """Tests for tf_agents.networks.encoding_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/networks/expand_dims_layer.py
+++ b/tf_agents/networks/expand_dims_layer.py
@@ -15,10 +15,6 @@
 
 """Keras layer performing the equivalent of tf.expand_dims."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 

--- a/tf_agents/networks/lstm_encoding_network.py
+++ b/tf_agents/networks/lstm_encoding_network.py
@@ -26,10 +26,6 @@ Implements a network that will generate the following layers:
   [optional]: Dense  # output_fc_layer_params
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/network.py
+++ b/tf_agents/networks/network.py
@@ -15,11 +15,6 @@
 
 """Base extension to Keras network to simplify copy operations."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 import typing
 

--- a/tf_agents/networks/network_test.py
+++ b/tf_agents/networks/network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.networks.network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/normal_projection_network.py
+++ b/tf_agents/networks/normal_projection_network.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Project inputs to a normal distribution object."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/networks/normal_projection_network_test.py
+++ b/tf_agents/networks/normal_projection_network_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.networks.normal_projection_network."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/networks/q_network.py
+++ b/tf_agents/networks/q_network.py
@@ -15,10 +15,6 @@
 
 """Sample Keras networks for DQN."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/q_network_test.py
+++ b/tf_agents/networks/q_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.network.q_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/q_rnn_network.py
+++ b/tf_agents/networks/q_rnn_network.py
@@ -15,10 +15,6 @@
 
 """Sample recurrent Keras network for DQN."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tensorflow.keras import layers

--- a/tf_agents/networks/q_rnn_network_test.py
+++ b/tf_agents/networks/q_rnn_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.networks.q_rnn_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.environments import suite_gym

--- a/tf_agents/networks/test_utils.py
+++ b/tf_agents/networks/test_utils.py
@@ -15,10 +15,6 @@
 
 """Common utility functions for testing."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from tf_agents.networks import network
 
 

--- a/tf_agents/networks/utils.py
+++ b/tf_agents/networks/utils.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Network utilities."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import composite
 

--- a/tf_agents/networks/utils_test.py
+++ b/tf_agents/networks/utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests tf_agents.utils.network_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.networks import utils

--- a/tf_agents/networks/value_network.py
+++ b/tf_agents/networks/value_network.py
@@ -25,10 +25,6 @@ Implements a network that will generate the following layers:
   Dense -> 1         # Value output
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/value_network_test.py
+++ b/tf_agents/networks/value_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.network.value_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.networks import value_network

--- a/tf_agents/networks/value_rnn_network.py
+++ b/tf_agents/networks/value_rnn_network.py
@@ -27,10 +27,6 @@ Implements a network that will generate the following layers:
   Dense -> 1         # Value output
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/networks/value_rnn_network_test.py
+++ b/tf_agents/networks/value_rnn_network_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.network.value_rnn_network."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.networks import value_rnn_network
 from tf_agents.specs import tensor_spec

--- a/tf_agents/policies/actor_policy.py
+++ b/tf_agents/policies/actor_policy.py
@@ -18,11 +18,6 @@
 This is used in e.g. actor-critic algorithms like DDPG.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/policies/actor_policy_test.py
+++ b/tf_agents/policies/actor_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.policies.actor_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/batched_py_policy.py
+++ b/tf_agents/policies/batched_py_policy.py
@@ -16,11 +16,6 @@
 # Lint as: python3
 """Treat multiple non-batch policies as a single batch policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 # pylint: disable=line-too-long
 # multiprocessing.dummy provides a pure *multithreaded* threadpool that works
 # in both python2 and python3 (concurrent.futures isn't available in python2).

--- a/tf_agents/policies/batched_py_policy_test.py
+++ b/tf_agents/policies/batched_py_policy_test.py
@@ -16,10 +16,6 @@
 # Lint as: python3
 """Tests for tf_agents.policies.batched_py_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import numpy as np

--- a/tf_agents/policies/boltzmann_policy.py
+++ b/tf_agents/policies/boltzmann_policy.py
@@ -15,11 +15,6 @@
 
 """Policy implementation that applies temperature to a distribution."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/policies/boltzmann_policy_test.py
+++ b/tf_agents/policies/boltzmann_policy_test.py
@@ -15,9 +15,6 @@
 
 """Test for tf_agents.policies.boltzmann_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.networks import network
 from tf_agents.policies import boltzmann_policy

--- a/tf_agents/policies/categorical_q_policy.py
+++ b/tf_agents/policies/categorical_q_policy.py
@@ -15,11 +15,6 @@
 
 """Simple Categorical Q-Policy for Q-Learning with Categorical DQN."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional
 
 import gin

--- a/tf_agents/policies/categorical_q_policy_test.py
+++ b/tf_agents/policies/categorical_q_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for learning.reinforcement_learning.policies.categorical_q_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from absl import flags
 

--- a/tf_agents/policies/epsilon_greedy_policy.py
+++ b/tf_agents/policies/epsilon_greedy_policy.py
@@ -18,11 +18,6 @@
 TODO(kbanoop): Make policy state optional in the action method.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/policies/epsilon_greedy_policy_test.py
+++ b/tf_agents/policies/epsilon_greedy_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.policies.epsilon_greedy_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 from absl.testing import parameterized
 import numpy as np

--- a/tf_agents/policies/fixed_policy.py
+++ b/tf_agents/policies/fixed_policy.py
@@ -18,11 +18,6 @@
 Mainly used for unit tests.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/fixed_policy_test.py
+++ b/tf_agents/policies/fixed_policy_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.policies.fixed_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.policies import fixed_policy

--- a/tf_agents/policies/gaussian_policy.py
+++ b/tf_agents/policies/gaussian_policy.py
@@ -15,11 +15,6 @@
 
 """A policy that wraps a given policy and adds Gaussian noise."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/gaussian_policy_test.py
+++ b/tf_agents/policies/gaussian_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for third_party.py.tf_agents.policies.gaussian_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/policies/greedy_policy.py
+++ b/tf_agents/policies/greedy_policy.py
@@ -15,11 +15,6 @@
 
 """Policy implementation that generates greedy actions from another policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/policies/greedy_policy_test.py
+++ b/tf_agents/policies/greedy_policy_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.policies.greedy_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/ou_noise_policy.py
+++ b/tf_agents/policies/ou_noise_policy.py
@@ -15,11 +15,6 @@
 
 """A policy that wraps a given policy and adds Ornstein Uhlenbeck (OU) noise."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/ou_noise_policy_test.py
+++ b/tf_agents/policies/ou_noise_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for third_party.py.tf_agents.policies.ou_noise_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.networks import network

--- a/tf_agents/policies/policy_info_updater_wrapper.py
+++ b/tf_agents/policies/policy_info_updater_wrapper.py
@@ -16,10 +16,6 @@
 # Lint as: python3
 """Policy wrapper that updates `policy_info` from wrapped policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from typing import Callable, Text, Dict, Union, Sequence, Optional
 
 import tensorflow.compat.v2 as tf

--- a/tf_agents/policies/policy_info_updater_wrapper_test.py
+++ b/tf_agents/policies/policy_info_updater_wrapper_test.py
@@ -17,10 +17,6 @@
 r"""Tests for tf_agents.policies.policy_info_updater_wrapper.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp

--- a/tf_agents/policies/policy_saver.py
+++ b/tf_agents/policies/policy_saver.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """TF-Agents SavedModel API."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import copy
 import functools
 import os

--- a/tf_agents/policies/policy_saver_test.py
+++ b/tf_agents/policies/policy_saver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for PolicySaver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/tf_agents/policies/py_epsilon_greedy_policy.py
+++ b/tf_agents/policies/py_epsilon_greedy_policy.py
@@ -16,11 +16,6 @@
 """epsilon-greedy policy in python.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional
 
 import numpy as np

--- a/tf_agents/policies/py_epsilon_greedy_policy_test.py
+++ b/tf_agents/policies/py_epsilon_greedy_policy_test.py
@@ -15,9 +15,6 @@
 
 """Tests for py_epsilon_greedy_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing.absltest import mock
 from tf_agents.policies import py_epsilon_greedy_policy
 from tf_agents.trajectories import policy_step

--- a/tf_agents/policies/py_policy.py
+++ b/tf_agents/policies/py_policy.py
@@ -15,12 +15,6 @@
 
 """Python Policies API."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
-
 import abc
 from typing import Optional
 

--- a/tf_agents/policies/py_tf_eager_policy.py
+++ b/tf_agents/policies/py_tf_eager_policy.py
@@ -15,11 +15,6 @@
 
 """Converts tf_policies when working in eager mode to py_policies."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import os
 from typing import Optional, Text
 

--- a/tf_agents/policies/py_tf_eager_policy_test.py
+++ b/tf_agents/policies/py_tf_eager_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.policies.eager_tf_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl.testing import parameterized

--- a/tf_agents/policies/py_tf_policy.py
+++ b/tf_agents/policies/py_tf_policy.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Converts TensorFlow Policies into Python Policies."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 from absl import logging
 

--- a/tf_agents/policies/py_tf_policy_test.py
+++ b/tf_agents/policies/py_tf_policy_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.utils.py_tf_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl import flags

--- a/tf_agents/policies/q_policy.py
+++ b/tf_agents/policies/q_policy.py
@@ -15,11 +15,6 @@
 
 """Simple Policy for DQN."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import gin

--- a/tf_agents/policies/q_policy_test.py
+++ b/tf_agents/policies/q_policy_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Test for tf_agents.policies.q_policy."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.networks import network

--- a/tf_agents/policies/random_py_policy.py
+++ b/tf_agents/policies/random_py_policy.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Policy implementation that generates random actions."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Sequence
 
 import numpy as np

--- a/tf_agents/policies/random_py_policy_test.py
+++ b/tf_agents/policies/random_py_policy_test.py
@@ -15,9 +15,6 @@
 
 """Test for tf_agents.utils.random_py_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.policies import random_py_policy

--- a/tf_agents/policies/random_tf_policy.py
+++ b/tf_agents/policies/random_tf_policy.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Policy implementation that generates random actions."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.distributions import masked
 from tf_agents.policies import tf_policy

--- a/tf_agents/policies/random_tf_policy_test.py
+++ b/tf_agents/policies/random_tf_policy_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.utils.random_tf_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import math
 
 from absl.testing import parameterized

--- a/tf_agents/policies/scripted_py_policy.py
+++ b/tf_agents/policies/scripted_py_policy.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """Policy implementation that steps over a given configuration."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Sequence, Tuple
 from absl import logging
 

--- a/tf_agents/policies/scripted_py_policy_test.py
+++ b/tf_agents/policies/scripted_py_policy_test.py
@@ -15,9 +15,6 @@
 
 """Tests for tf_agents.policies.scripted_py_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 
 from tf_agents.policies import scripted_py_policy

--- a/tf_agents/policies/temporal_action_smoothing.py
+++ b/tf_agents/policies/temporal_action_smoothing.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 
 """A TFPolicy wrapper that applies exponential moving averaging to actions."""
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/policies/temporal_action_smoothing_test.py
+++ b/tf_agents/policies/temporal_action_smoothing_test.py
@@ -15,10 +15,6 @@
 
 # Lint as: python2, python3
 """Tests for tf_agents.policies.temporal_action_smoothing."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 from six.moves import range

--- a/tf_agents/policies/tf_policy.py
+++ b/tf_agents/policies/tf_policy.py
@@ -15,11 +15,6 @@
 
 """TensorFlow Policies API."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import abc
 from typing import Optional, Text, Sequence
 

--- a/tf_agents/policies/tf_policy_test.py
+++ b/tf_agents/policies/tf_policy_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 
 import numpy as np

--- a/tf_agents/policies/tf_py_policy.py
+++ b/tf_agents/policies/tf_py_policy.py
@@ -15,11 +15,6 @@
 
 """Exposes a python policy as an in-graph TensorFlow policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 from typing import Optional, Text
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/policies/tf_py_policy_test.py
+++ b/tf_agents/policies/tf_py_policy_test.py
@@ -30,10 +30,6 @@
 
 """Test for tf_agents.policies.tf_py_policy."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing.absltest import mock
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/replay_buffers/episodic_replay_buffer.py
+++ b/tf_agents/replay_buffers/episodic_replay_buffer.py
@@ -15,10 +15,6 @@
 
 """An episodic replay buffer of nests of Tensors."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/replay_buffers/episodic_replay_buffer_driver_test.py
+++ b/tf_agents/replay_buffers/episodic_replay_buffer_driver_test.py
@@ -15,10 +15,6 @@
 
 """Tests for episodic_replay_buffer using driver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.drivers import dynamic_episode_driver

--- a/tf_agents/replay_buffers/episodic_replay_buffer_test.py
+++ b/tf_agents/replay_buffers/episodic_replay_buffer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for episodic_replay_buffer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/replay_buffers/episodic_table.py
+++ b/tf_agents/replay_buffers/episodic_table.py
@@ -21,10 +21,6 @@ a nest of Tensors.
 This class is not threadsafe.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import nest_utils
 

--- a/tf_agents/replay_buffers/episodic_table_test.py
+++ b/tf_agents/replay_buffers/episodic_table_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.replay_buffers.table."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 import numpy as np

--- a/tf_agents/replay_buffers/py_hashed_replay_buffer.py
+++ b/tf_agents/replay_buffers/py_hashed_replay_buffer.py
@@ -19,10 +19,6 @@ PyHashedReplayBuffer is a flavor of the base class which
 compresses the observations when the observations have some partial overlap
 (e.g. when using frame stacking).
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import pickle
 import threading
 

--- a/tf_agents/replay_buffers/py_replay_buffers_test.py
+++ b/tf_agents/replay_buffers/py_replay_buffers_test.py
@@ -15,9 +15,6 @@
 
 """Unit tests for PyUniformReplayBuffer and PyHashedReplayBuffer."""
 
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 
 from absl.testing import parameterized

--- a/tf_agents/replay_buffers/py_uniform_replay_buffer.py
+++ b/tf_agents/replay_buffers/py_uniform_replay_buffer.py
@@ -23,10 +23,6 @@ PyHashedReplayBuffer is a flavor of the base class which
 compresses the observations when the observations have some partial overlap
 (e.g. when using frame stacking).
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import threading
 
 import numpy as np

--- a/tf_agents/replay_buffers/replay_buffer.py
+++ b/tf_agents/replay_buffers/replay_buffer.py
@@ -15,10 +15,6 @@
 
 """TF-Agents Replay Buffer API."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/replay_buffers/replay_buffer_test.py
+++ b/tf_agents/replay_buffers/replay_buffer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.replay_buffers.replay_buffer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents import specs

--- a/tf_agents/replay_buffers/table.py
+++ b/tf_agents/replay_buffers/table.py
@@ -21,10 +21,6 @@ a nest of Tensors.
 This class is not threadsafe.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.utils import common

--- a/tf_agents/replay_buffers/table_test.py
+++ b/tf_agents/replay_buffers/table_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.replay_buffers.table."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import os
 

--- a/tf_agents/replay_buffers/tf_uniform_replay_buffer.py
+++ b/tf_agents/replay_buffers/tf_uniform_replay_buffer.py
@@ -24,10 +24,6 @@ needed for the batched replay buffer, but is returned to be consistent with
 the API for a priority replay buffer, which needs the ids to update priorities.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import gin
 import numpy as np

--- a/tf_agents/replay_buffers/tf_uniform_replay_buffer_test.py
+++ b/tf_agents/replay_buffers/tf_uniform_replay_buffer_test.py
@@ -15,9 +15,6 @@
 
 """Tests for tf_uniform_replay_buffer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """A class to describe the shape and dtype of numpy arrays."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numbers
 
 import gin

--- a/tf_agents/specs/array_spec_test.py
+++ b/tf_agents/specs/array_spec_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.environments.specs.array_spec."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/specs/distribution_spec.py
+++ b/tf_agents/specs/distribution_spec.py
@@ -15,10 +15,6 @@
 
 """Spec definition for tensorflow_probability.Distribution."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow_probability as tfp
 
 from tensorflow.python.util import nest  # pylint:disable=g-direct-tensorflow-import  # TF internal

--- a/tf_agents/specs/distribution_spec_test.py
+++ b/tf_agents/specs/distribution_spec_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.specs.distribution_spec."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp
 

--- a/tf_agents/specs/specs_test.py
+++ b/tf_agents/specs/specs_test.py
@@ -15,9 +15,6 @@
 
 """Tests reinforcement_learning.environments.specs without tensorflow."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 
 from tf_agents import specs

--- a/tf_agents/specs/tensor_spec.py
+++ b/tf_agents/specs/tensor_spec.py
@@ -15,10 +15,6 @@
 
 """Utilities related to TensorSpec class."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 import tensorflow_probability as tfp

--- a/tf_agents/specs/tensor_spec_test.py
+++ b/tf_agents/specs/tensor_spec_test.py
@@ -15,10 +15,6 @@
 
 """Tests for specs.tensor_spec."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/system/multiprocessing_test.py
+++ b/tf_agents/system/multiprocessing_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for tf_agents.system.multiprocessing."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import pickle
 
 from tf_agents.system import system_multiprocessing as multiprocessing

--- a/tf_agents/trajectories/policy_step.py
+++ b/tf_agents/trajectories/policy_step.py
@@ -15,11 +15,6 @@
 
 """Policy Step."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 from typing import NamedTuple, Optional, Union
 from tf_agents.typing import types

--- a/tf_agents/trajectories/policy_step_test.py
+++ b/tf_agents/trajectories/policy_step_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.trajectories.policy_step."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.trajectories import policy_step

--- a/tf_agents/trajectories/test_utils.py
+++ b/tf_agents/trajectories/test_utils.py
@@ -15,10 +15,6 @@
 
 """Utility functions for testing with trajectories."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.trajectories import trajectory

--- a/tf_agents/trajectories/time_step.py
+++ b/tf_agents/trajectories/time_step.py
@@ -15,11 +15,6 @@
 
 """TimeStep representing a step in the environment."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import numpy as np
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/trajectories/time_step_test.py
+++ b/tf_agents/trajectories/time_step_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for trajectories.time_step."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.specs import array_spec

--- a/tf_agents/trajectories/trajectory.py
+++ b/tf_agents/trajectories/trajectory.py
@@ -15,12 +15,6 @@
 
 """Trajectory containing time_step transition information."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
-
 import functools
 
 import numpy as np

--- a/tf_agents/trajectories/trajectory_test.py
+++ b/tf_agents/trajectories/trajectory_test.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """Tests for trajectory."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/typing/types.py
+++ b/tf_agents/typing/types.py
@@ -15,11 +15,6 @@
 
 """Common types used in TF-Agents."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import sys
 import typing
 from typing import Callable, Iterable, Mapping, Optional, Sequence, Text, Tuple, Union

--- a/tf_agents/utils/common.py
+++ b/tf_agents/utils/common.py
@@ -15,10 +15,6 @@
 
 """Common utilities for TF-Agents."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections as cs
 import contextlib
 import functools

--- a/tf_agents/utils/common_members_not_overridden_test.py
+++ b/tf_agents/utils/common_members_not_overridden_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.common.assert_members_are_not_overridden()."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import common
 

--- a/tf_agents/utils/common_test.py
+++ b/tf_agents/utils/common_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.utils.common."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import random
 

--- a/tf_agents/utils/composite.py
+++ b/tf_agents/utils/composite.py
@@ -16,10 +16,6 @@
 """Utilities for dealing with CompositeTensors.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 

--- a/tf_agents/utils/composite_test.py
+++ b/tf_agents/utils/composite_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.composite."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.utils import composite
 

--- a/tf_agents/utils/eager_utils.py
+++ b/tf_agents/utils/eager_utils.py
@@ -45,10 +45,6 @@ Example of usage:
   ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 import functools
 import inspect

--- a/tf_agents/utils/eager_utils_test.py
+++ b/tf_agents/utils/eager_utils_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.utils.eager_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 import itertools
 

--- a/tf_agents/utils/example_encoding.py
+++ b/tf_agents/utils/example_encoding.py
@@ -15,10 +15,6 @@
 
 """Utilities for easily encoding nests of numpy arrays into example protos."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import gin
 

--- a/tf_agents/utils/example_encoding_dataset.py
+++ b/tf_agents/utils/example_encoding_dataset.py
@@ -15,10 +15,6 @@
 
 """Utilities for for interacting with datasets of encoded examples of TFRecords."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl import logging
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/example_encoding_dataset_test.py
+++ b/tf_agents/utils/example_encoding_dataset_test.py
@@ -15,10 +15,6 @@
 
 """Tests for example_encoding_dataset."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import os
 import numpy as np

--- a/tf_agents/utils/example_encoding_test.py
+++ b/tf_agents/utils/example_encoding_test.py
@@ -15,10 +15,6 @@
 
 """Tests for example_encoding."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import gin
 import numpy as np

--- a/tf_agents/utils/nest_utils.py
+++ b/tf_agents/utils/nest_utils.py
@@ -15,11 +15,6 @@
 
 """Utilities for handling nested tensors."""
 
-from __future__ import absolute_import
-from __future__ import division
-# Using Type Annotations.
-from __future__ import print_function
-
 import collections
 import numbers
 

--- a/tf_agents/utils/nest_utils_test.py
+++ b/tf_agents/utils/nest_utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.nest_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/numpy_storage.py
+++ b/tf_agents/utils/numpy_storage.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 """NumpyStorage stores nested objects across multiple numpy arrays."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import io
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/numpy_storage_test.py
+++ b/tf_agents/utils/numpy_storage_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.numpy_storage."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/object_identity.py
+++ b/tf_agents/utils/object_identity.py
@@ -28,10 +28,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 # pylint: disable=unused-import
 # pylint: disable=g-import-not-at-top
 try:  # pylint: disable=g-statement-before-imports

--- a/tf_agents/utils/object_identity_test.py
+++ b/tf_agents/utils/object_identity_test.py
@@ -29,10 +29,6 @@
 # ==============================================================================
 """Unit tests for object_identity."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.utils import object_identity

--- a/tf_agents/utils/session_utils.py
+++ b/tf_agents/utils/session_utils.py
@@ -17,10 +17,6 @@
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 

--- a/tf_agents/utils/session_utils_test.py
+++ b/tf_agents/utils/session_utils_test.py
@@ -15,10 +15,6 @@
 
 """Tests for learning.reinforment_learning.utils.session_user."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.utils import session_utils

--- a/tf_agents/utils/tensor_normalizer.py
+++ b/tf_agents/utils/tensor_normalizer.py
@@ -38,10 +38,6 @@ with tf.Session() as sess:
     ...
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 

--- a/tf_agents/utils/tensor_normalizer_test.py
+++ b/tf_agents/utils/tensor_normalizer_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.tensor_normalizer."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/test_utils.py
+++ b/tf_agents/utils/test_utils.py
@@ -15,10 +15,6 @@
 
 """Common utility functions for testing."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 from absl import flags

--- a/tf_agents/utils/test_utils_test.py
+++ b/tf_agents/utils/test_utils_test.py
@@ -15,9 +15,6 @@
 
 """Tests for utils/test_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 from tf_agents.utils import test_utils
 

--- a/tf_agents/utils/timer.py
+++ b/tf_agents/utils/timer.py
@@ -15,10 +15,6 @@
 
 """Timing utility for TF-Agents."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import time
 
 

--- a/tf_agents/utils/value_ops_test.py
+++ b/tf_agents/utils/value_ops_test.py
@@ -15,10 +15,6 @@
 
 """Tests for tf_agents.utils.generalized_advantage_estimation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/xla.py
+++ b/tf_agents/utils/xla.py
@@ -15,10 +15,6 @@
 
 """XLA utilities for TF-Agents."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import functools
 
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import

--- a/tf_agents/utils/xla_test.py
+++ b/tf_agents/utils/xla_test.py
@@ -15,10 +15,6 @@
 
 """Test for tf_agents.utils.xla."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 from tf_agents.utils import xla

--- a/tools/test_colabs.py
+++ b/tools/test_colabs.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 """Tests colabs using Jupyter notebook."""
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
These functions no longer need to be imported from `__future__` now that the TF-Agents project no longer supports Python 2.

c.f. #398 