### PR TITLE
Allow to customize rnn construction fn on QRnnNetwork

### DIFF
--- a/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent_test.py
+++ b/tf_agents/agents/behavioral_cloning/behavioral_cloning_agent_test.py
@@ -283,7 +283,7 @@ class BehavioralCloningAgentTest(test_utils.TestCase, parameterized.TestCase):
     # Hard code a trajectory shaped (time=6, batch=1, ...).
     traj, time_step_spec, action_spec = create_arbitrary_trajectory()
     cloning_net = q_rnn_network.QRnnNetwork(
-        time_step_spec.observation, action_spec)
+        time_step_spec.observation, action_spec, lstm_size=(40,))
     agent = behavioral_cloning_agent.BehavioralCloningAgent(
         time_step_spec,
         action_spec,

--- a/tf_agents/networks/q_rnn_network.py
+++ b/tf_agents/networks/q_rnn_network.py
@@ -39,9 +39,11 @@ class QRnnNetwork(lstm_encoding_network.LSTMEncodingNetwork):
       preprocessing_combiner=None,
       conv_layer_params=None,
       input_fc_layer_params=(75, 40),
-      lstm_size=(40,),
+      lstm_size=None,
       output_fc_layer_params=(75, 40),
       activation_fn=tf.keras.activations.relu,
+      rnn_construction_fn=None,
+      rnn_construction_kwargs=None,
       dtype=tf.float32,
       name='QRnnNetwork',
   ):
@@ -72,6 +74,17 @@ class QRnnNetwork(lstm_encoding_network.LSTMEncodingNetwork):
         each item is the number of units in the layer. These are applied on top
         of the recurrent layer.
       activation_fn: Activation function, e.g. tf.keras.activations.relu,.
+      rnn_construction_fn: (Optional.) Alternate RNN construction function, e.g.
+        tf.keras.layers.LSTM, tf.keras.layers.CuDNNLSTM. It is invalid to
+        provide both rnn_construction_fn and lstm_size.
+      rnn_construction_kwargs: (Optional.) Dictionary or arguments to pass to
+        rnn_construction_fn.
+
+        The RNN will be constructed via:
+
+        ```
+        rnn_layer = rnn_construction_fn(**rnn_construction_kwargs)
+        ```
       dtype: The dtype to use by the convolution, LSTM, and fully connected
         layers.
       name: A string representing name of the network.
@@ -80,6 +93,8 @@ class QRnnNetwork(lstm_encoding_network.LSTMEncodingNetwork):
       ValueError: If any of `preprocessing_layers` is already built.
       ValueError: If `preprocessing_combiner` is already built.
       ValueError: If `action_spec` contains more than one action.
+      ValueError: If neither `lstm_size` nor `rnn_construction_fn` are provided.
+      ValueError: If both `lstm_size` and `rnn_construction_fn` are provided.
     """
     q_network.validate_specs(action_spec, input_tensor_spec)
     action_spec = tf.nest.flatten(action_spec)[0]
@@ -103,6 +118,8 @@ class QRnnNetwork(lstm_encoding_network.LSTMEncodingNetwork):
         lstm_size=lstm_size,
         output_fc_layer_params=output_fc_layer_params,
         activation_fn=activation_fn,
+        rnn_construction_fn=rnn_construction_fn,
+        rnn_construction_kwargs=rnn_construction_kwargs,
         dtype=dtype,
         name=name)
 

--- a/tf_agents/networks/q_rnn_network_test.py
+++ b/tf_agents/networks/q_rnn_network_test.py
@@ -28,6 +28,10 @@ from tf_agents.networks import q_rnn_network
 from tf_agents.specs import tensor_spec
 from tf_agents.trajectories import time_step
 
+def rnn_keras_fn(lstm_size):
+    cell = tf.keras.layers.SimpleRNNCell(lstm_size)
+    return tf.keras.layers.RNN(cell, return_state=True,
+                               return_sequences=True)
 
 class QRnnNetworkTest(tf.test.TestCase):
 
@@ -35,7 +39,8 @@ class QRnnNetworkTest(tf.test.TestCase):
     env = suite_gym.load('CartPole-v0')
     tf_env = tf_py_environment.TFPyEnvironment(env)
     rnn_network = q_rnn_network.QRnnNetwork(tf_env.observation_spec(),
-                                            tf_env.action_spec())
+                                            tf_env.action_spec(),
+                                            lstm_size=(40,))
 
     first_time_step = tf_env.current_time_step()
     q_values, state = rnn_network(
@@ -127,6 +132,22 @@ class QRnnNetworkTest(tf.test.TestCase):
     self.assertEqual((1, 10), state[0][1].shape)
     self.assertEqual((1, 5), state[1][0].shape)
     self.assertEqual((1, 5), state[1][1].shape)
+
+  def test_network_builds_rnn_construction_fn(self):
+      env = suite_gym.load('CartPole-v0')
+      tf_env = tf_py_environment.TFPyEnvironment(env)
+      rnn_network = q_rnn_network.QRnnNetwork(tf_env.observation_spec(),
+                                              tf_env.action_spec(),
+                                              rnn_construction_fn=rnn_keras_fn,
+                                              rnn_construction_kwargs={'lstm_size': 3})
+
+      first_time_step = tf_env.current_time_step()
+      q_values, state = rnn_network(
+          first_time_step.observation, first_time_step.step_type,
+          network_state=rnn_network.get_initial_state(batch_size=1),
+      )
+      self.assertEqual((1, 2), q_values.shape)
+      self.assertEqual((3,), state[0].shape)
 
 
 if __name__ == '__main__':

--- a/tf_agents/policies/policy_saver_test.py
+++ b/tf_agents/policies/policy_saver_test.py
@@ -181,7 +181,8 @@ class PolicySaverTest(test_utils.TestCase, parameterized.TestCase):
           if has_state:
             network = q_rnn_network.QRnnNetwork(
                 input_tensor_spec=self._time_step_spec.observation,
-                action_spec=self._action_spec)
+                action_spec=self._action_spec,
+                lstm_size=(40,))
           else:
             network = q_network.QNetwork(
                 input_tensor_spec=self._time_step_spec.observation,
@@ -367,7 +368,8 @@ class PolicySaverTest(test_utils.TestCase, parameterized.TestCase):
   def testSaveGetInitialState(self):
     network = q_rnn_network.QRnnNetwork(
         input_tensor_spec=self._time_step_spec.observation,
-        action_spec=self._action_spec)
+        action_spec=self._action_spec,
+        lstm_size=(40,))
 
     policy = q_policy.QPolicy(
         time_step_spec=self._time_step_spec,


### PR DESCRIPTION
This PR adds a parameter to QRnnNetwork, which allows to customise the function used to create the rnn (for instance, to use tf.keras LSTM or CuDNNLSTM).

The parameters are sent directly to LSTMEncodingNetwork which already had support for the functionality. These parameters were already added to ActorDistributionNetwork in [this commit](https://github.com/tensorflow/agents/commit/452cf41746dd7c4572b6e6766185431bce7f5ee1).
