### PR TITLE
Ensure the variable dtype is used with the variable initializer when creating a variable.

### DIFF
--- a/tf_agents/utils/common.py
+++ b/tf_agents/utils/common.py
@@ -212,7 +212,7 @@ def create_variable(name,
         initial_value = tf.convert_to_tensor(initial_value, dtype=dtype)
     else:
       if callable(initializer):
-        initial_value = lambda: initializer(shape)
+        initial_value = lambda: initializer(shape, dtype)
       else:
         initial_value = initializer
     return tf.compat.v2.Variable(

--- a/tf_agents/utils/common_test.py
+++ b/tf_agents/utils/common_test.py
@@ -69,6 +69,14 @@ class CreateCounterTest(test_utils.TestCase):
     self.evaluate(tf.compat.v1.global_variables_initializer())
     self.assertAllEqual(self.evaluate(var), [1, 2])
 
+  def testInitializerDType(self):
+    var = common.create_variable(
+      'var', dtype=tf.int64,
+      initializer=tf.random_uniform_initializer(minval=0, maxval=1)
+    )
+    self.evaluate(tf.compat.v1.global_variables_initializer())
+    self.assertEqual(var.dtype, tf.int64)
+
 
 class SoftVariablesUpdateTest(test_utils.TestCase, parameterized.TestCase):
 


### PR DESCRIPTION
Fix #406 .