### PR TITLE
Fix a typo in 5_replay_buffers_tutorial.ipynb

### DIFF
--- a/docs/tutorials/5_replay_buffers_tutorial.ipynb
+++ b/docs/tutorials/5_replay_buffers_tutorial.ipynb
@@ -393,7 +393,7 @@
       },
       "source": [
         "## Using replay buffers during training\n",
-        "Now that we know how to created a replay buffer, write items to it and read from it, we can use it to store trajectories during training of our agents. \n",
+        "Now that we know how to create a replay buffer, write items to it and read from it, we can use it to store trajectories during training of our agents. \n",
         "\n",
         "### Data collection\n",
         "First, let's look at how to use the replay buffer during data collection.\n",


### PR DESCRIPTION
Original line: 

> Now that we know how to **created** a replay buffer, write items to it and read from it, we can use it to store trajectories during training of our agents. 

Fixed line: 

> Now that we know how to **create** a replay buffer, write items to it and read from it, we can use it to store trajectories during training of our agents. 