### PR TITLE
Reverse summation order in nested_kl_divergence() in PPO

### DIFF
--- a/tf_agents/agents/ppo/ppo_utils.py
+++ b/tf_agents/agents/ppo/ppo_utils.py
@@ -126,14 +126,17 @@ def nested_kl_divergence(nested_from_distribution: types.NestedDistribution,
                         for from_dist, to_dist
                         in zip(flat_from_distribution, flat_to_distribution)]
 
+  all_kl_divergences_reduced = []
+  for kl_divergence in all_kl_divergences:
+    # Reduce_sum over non-batch dimensions.
+    reduce_dims = list(range(len(kl_divergence.shape)))
+    for dim in outer_dims:
+      reduce_dims.remove(dim)
+    all_kl_divergences_reduced.append(
+        tf.reduce_sum(input_tensor=kl_divergence, axis=reduce_dims))
+   
   # Sum the kl of the leaves.
-  summed_kl_divergences = tf.add_n(all_kl_divergences)
-
-  # Reduce_sum over non-batch dimensions.
-  reduce_dims = list(range(len(summed_kl_divergences.shape)))
-  for dim in outer_dims:
-    reduce_dims.remove(dim)
-  total_kl = tf.reduce_sum(input_tensor=summed_kl_divergences, axis=reduce_dims)
+  total_kl = tf.add_n(all_kl_divergences_reduced)
 
   return total_kl
 

--- a/tf_agents/agents/ppo/ppo_utils_test.py
+++ b/tf_agents/agents/ppo/ppo_utils_test.py
@@ -77,6 +77,22 @@ class PPOUtilsTest(parameterized.TestCase, tf.test.TestCase):
     kl_divergence_ = self.evaluate(kl_divergence)
     self.assertAllClose(expected_kl_divergence, kl_divergence_)
 
+    # test for distributions with different shapes
+    one_reshaped = tf.constant([[1.0]] * 3, dtype=tf.float32)
+    dist_neg_one_reshaped = tfp.distributions.Normal(
+        loc=-one_reshaped, scale=one_reshaped)
+    dist_one_reshaped = tfp.distributions.Normal(
+        loc=one_reshaped, scale=one_reshaped)
+
+    nested_dist1 = [dist_zero, [dist_neg_one_reshaped, dist_one]]
+    nested_dist2 = [dist_one, [dist_one_reshaped, dist_zero]]
+    kl_divergence = ppo_utils.nested_kl_divergence(
+        nested_dist1, nested_dist2)
+    expected_kl_divergence = 3 * 3.0  # 3 * (0.5 + (2.0 + 0.5))
+
+    kl_divergence_ = self.evaluate(kl_divergence)
+    self.assertAllClose(expected_kl_divergence, kl_divergence_)
+
   def test_get_distribution_params(self):
     ones = tf.ones(shape=[2], dtype=tf.float32)
     distribution = (tfp.distributions.Categorical(logits=ones),


### PR DESCRIPTION
nested_kl_divergence() in ppo_utils.py wasn't summing up the individual contributions to KL correctly, if the nested actions have different shapes. In this commit the order of operations is reversed: first the sum is done over time steps, which brings all KL contributions to the same shape, and then the sum over actions produces a total_kl. Fixes #439.