### PR TITLE
Fix for multi worker PPO

### DIFF
--- a/tf_agents/agents/ppo/ppo_agent.py
+++ b/tf_agents/agents/ppo/ppo_agent.py
@@ -801,6 +801,9 @@ class PPOAgent(tf_agent.TFAgent):
     variables_to_train = list(
         object_identity.ObjectIdentitySet(self._actor_net.trainable_weights +
                                           self._value_net.trainable_weights))
+    # Sort to ensure tensors on different processes end up in same order.
+    variables_to_train = sorted(variables_to_train, key=lambda x: x.name)
+
     for i_epoch in range(self._num_epochs):
       with tf.name_scope('epoch_%d' % i_epoch):
         # Only save debug summaries for first and last epochs.


### PR DESCRIPTION
When using the PPO Agent combined with the MirroredStrategy there is a chance that tensors are not in the same order. This causes issues during the communication phase. This change ensures that the tensors on each replica have the same order.

Currently you can get something like the below where the 'variables_to_train' is ordered differently.

Replica 1
```
[MirroredVariable:{
  0: <tf.Variable 'ActorDistributionNetwork/EncodingNetwork/dense/bias:0' shape=(200,) dtype=float32>
}, MirroredVariable:{
  0: <tf.Variable 'ActorDistributionNetwork/NormalProjectionNetwork/means_projection_layer/kernel:0' shape=(100, 2) dtype=float32>
}, MirroredVariable:{
  0: <tf.Variable 'ValueNetwork/dense_4/bias:0' shape=(1,) dtype=float32>
....  
, MirroredVariable:{
  0: <tf.Variable 'ValueNetwork/EncodingNetwork/dense_2/bias:0' shape=(200,) dtype=float32>
}, MirroredVariable:{
  0: <tf.Variable 'ActorDistributionNetwork/EncodingNetwork/dense_1/kernel:0' shape=(200, 100) dtype=float32>
}]

```
Replica 2:
```
[MirroredVariable:{
  0: <tf.Variable 'ActorDistributionNetwork/EncodingNetwork/dense_1/kernel:0' shape=(200, 100) dtype=float32>
}, MirroredVariable:{
  0: <tf.Variable 'ValueNetwork/EncodingNetwork/dense_2/bias:0' shape=(200,) dtype=float32>
}, MirroredVariable:{
  0: <tf.Variable 'ActorDistributionNetwork/NormalProjectionNetwork/means_projection_layer/kernel:0' shape=(100, 2) dtype=float32>
}, MirroredVariable:{
```
...