### PR TITLE
Fix for #281 unused variable in DQN tutorial

### DIFF
--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -218,7 +218,7 @@
       "source": [
         "num_iterations = 20000 # @param {type:\"integer\"}\n",
         "\n",
-        "initial_collect_steps = 1000  # @param {type:\"integer\"} \n",
+        "initial_collect_steps = 100  # @param {type:\"integer\"} \n",
         "collect_steps_per_iteration = 1  # @param {type:\"integer\"}\n",
         "replay_buffer_max_length = 100000  # @param {type:\"integer\"}\n",
         "\n",
@@ -800,7 +800,7 @@
         "  for _ in range(steps):\n",
         "    collect_step(env, policy, buffer)\n",
         "\n",
-        "collect_data(train_env, random_policy, replay_buffer, steps=100)\n",
+        "collect_data(train_env, random_policy, replay_buffer, initial_collect_steps)\n",
         "\n",
         "# This loop is so common in RL, that we provide standard implementations. \n",
         "# For more details see the drivers module.\n",


### PR DESCRIPTION
I have noticed `initial_collect_steps` wasn't used in the DQN tutorial. Issue #281 has also addressed this.

Kind regards,
Thijs