### PR TITLE
Fixed typo: parellalize > parallelize

### DIFF
--- a/docs/tutorials/2_environments_tutorial.ipynb
+++ b/docs/tutorials/2_environments_tutorial.ipynb
@@ -536,7 +536,7 @@
         "* They generate tensor objects instead of arrays\n",
         "* TF environments add a batch dimension to the tensors generated when compared to the specs. \n",
         "\n",
-        "Converting the python environments into TFEnvs allows tensorflow to parellalize operations. For example, one could define a `collect_experience_op` that collects data from the environment and adds to a `replay_buffer`, and a `train_op` that reads from the `replay_buffer` and trains the agent, and run them in parallel naturally in TensorFlow."
+        "Converting the python environments into TFEnvs allows tensorflow to parallelize operations. For example, one could define a `collect_experience_op` that collects data from the environment and adds to a `replay_buffer`, and a `train_op` that reads from the `replay_buffer` and trains the agent, and run them in parallel naturally in TensorFlow."
       ]
     },
     {


### PR DESCRIPTION
Small typo in the Environments tutorial.