### PR TITLE
Fix never ending recursion in Environments guide notebook

### DIFF
--- a/docs/tutorials/2_environments_tutorial.ipynb
+++ b/docs/tutorials/2_environments_tutorial.ipynb
@@ -225,9 +225,7 @@
         "\n",
         "  @abc.abstractmethod\n",
         "  def _step(self, action):\n",
-        "    \"\"\"Apply action and return new time_step.\"\"\"\n",
-        "    self._current_time_step = self._step(action)\n",
-        "    return self._current_time_step"
+        "    \"\"\"Apply action and return new time_step.\"\"\""
       ]
     },
     {


### PR DESCRIPTION
The "example" implementation given for the abstract method in the notebook is not an accurate description of what the implementation of the `_step` method of a `PyEnvironment` should do. Also, the current example would lead to a never ending recursion.