### PR TITLE
Typo ' instead of ` in multiple files

### DIFF
--- a/tf_agents/agents/ddpg/actor_network.py
+++ b/tf_agents/agents/ddpg/actor_network.py
@@ -54,7 +54,7 @@ class ActorNetwork(network.Network):
       dropout_layer_params: Optional list of dropout layer parameters, each item
         is the fraction of input units to drop or a dictionary of parameters
         according to the keras.Dropout documentation. The additional parameter
-        `permanent', if set to True, allows to apply dropout at inference for
+        `permanent`, if set to True, allows to apply dropout at inference for
         approximated Bayesian inference. The dropout layers are interleaved with
         the fully connected layers; there is a dropout layer after each fully
         connected layer, except if the entry in the list is None. This list must

--- a/tf_agents/agents/ddpg/critic_network.py
+++ b/tf_agents/agents/ddpg/critic_network.py
@@ -53,7 +53,7 @@ class CriticNetwork(network.Network):
       observation_dropout_layer_params: Optional list of dropout layer
         parameters, each item is the fraction of input units to drop or a
         dictionary of parameters according to the keras.Dropout documentation.
-        The additional parameter `permanent', if set to True, allows to apply
+        The additional parameter `permanent`, if set to True, allows to apply
         dropout at inference for approximated Bayesian inference. The dropout
         layers are interleaved with the fully connected layers; there is a
         dropout layer after each fully connected layer, except if the entry in
@@ -64,7 +64,7 @@ class CriticNetwork(network.Network):
       action_dropout_layer_params: Optional list of dropout layer parameters,
         each item is the fraction of input units to drop or a dictionary of
         parameters according to the keras.Dropout documentation. The additional
-        parameter `permanent', if set to True, allows to apply dropout at
+        parameter `permanent`, if set to True, allows to apply dropout at
         inference for approximated Bayesian inference. The dropout layers are
         interleaved with the fully connected layers; there is a dropout layer
         after each fully connected layer, except if the entry in the list is
@@ -76,7 +76,7 @@ class CriticNetwork(network.Network):
       joint_dropout_layer_params: Optional list of dropout layer parameters,
         each item is the fraction of input units to drop or a dictionary of
         parameters according to the keras.Dropout documentation. The additional
-        parameter `permanent', if set to True, allows to apply dropout at
+        parameter `permanent`, if set to True, allows to apply dropout at
         inference for approximated Bayesian inference. The dropout layers are
         interleaved with the fully connected layers; there is a dropout layer
         after each fully connected layer, except if the entry in the list is

--- a/tf_agents/networks/actor_distribution_network.py
+++ b/tf_agents/networks/actor_distribution_network.py
@@ -97,7 +97,7 @@ class ActorDistributionNetwork(network.DistributionNetwork):
       dropout_layer_params: Optional list of dropout layer parameters, each item
         is the fraction of input units to drop or a dictionary of parameters
         according to the keras.Dropout documentation. The additional parameter
-        `permanent', if set to True, allows to apply dropout at inference for
+        `permanent`, if set to True, allows to apply dropout at inference for
         approximated Bayesian inference. The dropout layers are interleaved with
         the fully connected layers; there is a dropout layer after each fully
         connected layer, except if the entry in the list is None. This list must

--- a/tf_agents/networks/actor_distribution_rnn_network.py
+++ b/tf_agents/networks/actor_distribution_rnn_network.py
@@ -100,7 +100,7 @@ class ActorDistributionRnnNetwork(network.DistributionNetwork):
       input_dropout_layer_params: Optional list of dropout layer parameters,
         each item is the fraction of input units to drop or a dictionary of
         parameters according to the keras.Dropout documentation. The additional
-        parameter `permanent', if set to True, allows to apply dropout at
+        parameter `permanent`, if set to True, allows to apply dropout at
         inference for approximated Bayesian inference. The dropout layers are
         interleaved with the fully connected layers; there is a dropout layer
         after each fully connected layer, except if the entry in the list is

--- a/tf_agents/networks/encoding_network.py
+++ b/tf_agents/networks/encoding_network.py
@@ -161,7 +161,7 @@ class EncodingNetwork(network.Network):
       dropout_layer_params: Optional list of dropout layer parameters, each item
         is the fraction of input units to drop or a dictionary of parameters
         according to the keras.Dropout documentation. The additional parameter
-        `permanent', if set to True, allows to apply dropout at inference for
+        `permanent`, if set to True, allows to apply dropout at inference for
         approximated Bayesian inference. The dropout layers are interleaved with
         the fully connected layers; there is a dropout layer after each fully
         connected layer, except if the entry in the list is None. This list must

--- a/tf_agents/networks/encoding_network.py
+++ b/tf_agents/networks/encoding_network.py
@@ -116,7 +116,7 @@ class EncodingNetwork(network.Network):
 
     ```python
     preprocessed = [preprocessing_layers[0](observations[0]),
-                    preprocessing_layers[1](obsrevations[1])]
+                    preprocessing_layers[1](observations[1])]
     ```
 
     However if

--- a/tf_agents/networks/lstm_encoding_network.py
+++ b/tf_agents/networks/lstm_encoding_network.py
@@ -78,7 +78,7 @@ class LSTMEncodingNetwork(network.Network):
 
     ```python
     preprocessed = [preprocessing_layers[0](observations[0]),
-                    preprocessing_layers[1](obsrevations[1])]
+                    preprocessing_layers[1](observations[1])]
     ```
 
     However if

--- a/tf_agents/networks/utils.py
+++ b/tf_agents/networks/utils.py
@@ -153,7 +153,7 @@ def mlp_layers(conv_layer_params=None,
     dropout_layer_params: Optional list of dropout layer parameters, each item
       is the fraction of input units to drop or a dictionary of parameters
       according to the keras.Dropout documentation. The additional parameter
-      `permanent', if set to True, allows to apply dropout at inference for
+      `permanent`, if set to True, allows to apply dropout at inference for
       approximated Bayesian inference. The dropout layers are interleaved with
       the fully connected layers; there is a dropout layer after each fully
       connected layer, except if the entry in the list is None. This list must

--- a/tf_agents/networks/value_network.py
+++ b/tf_agents/networks/value_network.py
@@ -77,7 +77,7 @@ class ValueNetwork(network.Network):
       dropout_layer_params: Optional list of dropout layer parameters, each item
         is the fraction of input units to drop or a dictionary of parameters
         according to the keras.Dropout documentation. The additional parameter
-        `permanent', if set to True, allows to apply dropout at inference for
+        `permanent`, if set to True, allows to apply dropout at inference for
         approximated Bayesian inference. The dropout layers are interleaved with
         the fully connected layers; there is a dropout layer after each fully
         connected layer, except if the entry in the list is None. This list must


### PR DESCRIPTION
Causing too much bold text and broken HTML tags in documentation: https://www.tensorflow.org/agents/api_docs/python/tf_agents/networks/encoding_network/EncodingNetwork