### PR TITLE
Consistent casing: python -> Python

### DIFF
--- a/docs/tutorials/2_environments_tutorial.ipynb
+++ b/docs/tutorials/2_environments_tutorial.ipynb
@@ -178,7 +178,7 @@
         "\n",
         "These are grouped into a named tuple `TimeStep(step_type, reward, discount, observation)`.\n",
         "\n",
-        "The interface that all python environments must implement is in `environments/py_environment.PyEnvironment`. The main methods are:"
+        "The interface that all Python environments must implement is in `environments/py_environment.PyEnvironment`. The main methods are:"
       ]
     },
     {
@@ -456,7 +456,7 @@
       "source": [
         "### Environment Wrappers\n",
         "\n",
-        "An environment wrapper takes a python environment and returns a modified version of the environment. Both the original environment and the modified environment are instances of `py_environment.PyEnvironment`, and multiple wrappers can be chained together.\n",
+        "An environment wrapper takes a Python environment and returns a modified version of the environment. Both the original environment and the modified environment are instances of `py_environment.PyEnvironment`, and multiple wrappers can be chained together.\n",
         "\n",
         "Some common wrappers can be found in `environments/wrappers.py`. For example:\n",
         "\n",
@@ -509,7 +509,7 @@
         "id": "njFjW8bmwTWJ"
       },
       "source": [
-        "The wrapped `discrete_action_env` is an instance of `py_environment.PyEnvironment` and can be treated like a regular python environment.\n"
+        "The wrapped `discrete_action_env` is an instance of `py_environment.PyEnvironment` and can be treated like a regular Python environment.\n"
       ]
     },
     {
@@ -529,12 +529,12 @@
         "id": "iZG39AjBkTjr"
       },
       "source": [
-        "The interface for TF environments is defined in `environments/tf_environment.TFEnvironment` and looks very similar to the Python environments. TF Environments differ from python envs in a couple of ways:\n",
+        "The interface for TF environments is defined in `environments/tf_environment.TFEnvironment` and looks very similar to the Python environments. TF Environments differ from Python envs in a couple of ways:\n",
         "\n",
         "* They generate tensor objects instead of arrays\n",
         "* TF environments add a batch dimension to the tensors generated when compared to the specs. \n",
         "\n",
-        "Converting the python environments into TFEnvs allows tensorflow to parallelize operations. For example, one could define a `collect_experience_op` that collects data from the environment and adds to a `replay_buffer`, and a `train_op` that reads from the `replay_buffer` and trains the agent, and run them in parallel naturally in TensorFlow."
+        "Converting the Python environments into TFEnvs allows tensorflow to parallelize operations. For example, one could define a `collect_experience_op` that collects data from the environment and adds to a `replay_buffer`, and a `train_op` that reads from the `replay_buffer` and trains the agent, and run them in parallel naturally in TensorFlow."
       ]
     },
     {

--- a/docs/tutorials/3_policies_tutorial.ipynb
+++ b/docs/tutorials/3_policies_tutorial.ipynb
@@ -86,7 +86,7 @@
         "\n",
         "Policies are related to other components in TF-Agents in the following way. Most policies have a neural network to compute actions and/or distributions over actions from TimeSteps. Agents can contain one or more policies for different purposes, e.g. a main policy that is being trained for deployment, and a noisy policy for data collection. Policies can be saved/restored, and can be used indepedently of the agent for data collection, evaluation etc.\n",
         "\n",
-        "Some policies are easier to write in Tensorflow (e.g. those with a neural network), whereas others are easier to write in Python (e.g. following a script of actions). So in TF agents, we allow both Python and Tensorflow policies. Morever, policies written in TensorFlow might have to be used in a Python environment, or vice versa, e.g. a TensorFlow policy is used for training but later deployed in a production python environment. To make this easier, we provide wrappers for converting between python and TensorFlow policies.\n",
+        "Some policies are easier to write in Tensorflow (e.g. those with a neural network), whereas others are easier to write in Python (e.g. following a script of actions). So in TF agents, we allow both Python and Tensorflow policies. Morever, policies written in TensorFlow might have to be used in a Python environment, or vice versa, e.g. a TensorFlow policy is used for training but later deployed in a production Python environment. To make this easier, we provide wrappers for converting between Python and TensorFlow policies.\n",
         "\n",
         "Another interesting class of policies are policy wrappers, which modify a given policy in a certain way, e.g. add a particular type of noise, make a greedy or epsilon-greedy version of a stochastic policy, randomly mix multiple policies etc.  "
       ]
@@ -248,7 +248,7 @@
         "\n",
         "The `time_step_spec` and `action_spec` are specifications for the input time step and the output action. Policies also have a `reset` function which is typically used for resetting the state in stateful policies. The `update(new_policy)` function updates `self` towards `new_policy`.\n",
         "\n",
-        "Now, let us look at a couple of examples of python policies.\n"
+        "Now, let us look at a couple of examples of Python policies.\n"
       ]
     },
     {


### PR DESCRIPTION
Use consistent casing for `Python` in the whole document