### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tf_agents/keras_layers/bias_layer.py
+++ b/tf_agents/keras_layers/bias_layer.py
@@ -27,7 +27,7 @@ class BiasLayer(tf.keras.layers.Layer):
   `BiasLayer` implements the operation:
   `output = input + bias`
 
-  Arguments:
+  Args:
       bias_initializer: Initializer for the bias vector.
   Input shape:
       nD tensor with shape: `(batch_size, ..., input_dim)`. The most common

--- a/tf_agents/networks/expand_dims_layer.py
+++ b/tf_agents/networks/expand_dims_layer.py
@@ -25,7 +25,7 @@ import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 class ExpandDims(tf.keras.layers.Layer):
   """Expands dims along a particular axis.
 
-  Arguments:
+  Args:
       axis: Axis to expand.  A new dim is added before this axis.
          May be a negative value.  Must not be a tensor.
 

--- a/tf_agents/networks/network.py
+++ b/tf_agents/networks/network.py
@@ -266,7 +266,7 @@ class Network(tf.keras.layers.Layer):
     If `name` and `index` are both provided, `index` will take precedence.
     Indices are based on order of horizontal graph traversal (bottom-up).
 
-    Arguments:
+    Args:
         name: String, name of layer.
         index: Integer, index of layer.
 


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420