### PR TITLE
Change from using gather_all to as_dataset in PPO example.

### DIFF
--- a/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
+++ b/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
@@ -222,13 +222,13 @@ def train_eval(
         num_episodes=collect_episodes_per_iteration)
 
     def train_step():
-        ds = replay_buffer.as_dataset(
-            sample_batch_size=num_parallel_environments,
-            num_steps=replay_buffer.num_frames() // num_parallel_environments,
-            single_deterministic_pass=True
-        )
+      ds = replay_buffer.as_dataset(
+        sample_batch_size=num_parallel_environments,
+        num_steps=replay_buffer.num_frames() // num_parallel_environments,
+        single_deterministic_pass=True
+      )
 
-        return tf_agent.train(experience=iter(ds).get_next()[0])
+      return tf_agent.train(experience=iter(ds).get_next()[0])
 
 
     if use_tf_functions:

--- a/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
+++ b/tf_agents/agents/ppo/examples/v2/train_eval_clip_agent.py
@@ -222,8 +222,14 @@ def train_eval(
         num_episodes=collect_episodes_per_iteration)
 
     def train_step():
-      trajectories = replay_buffer.gather_all()
-      return tf_agent.train(experience=trajectories)
+        ds = replay_buffer.as_dataset(
+            sample_batch_size=num_parallel_environments,
+            num_steps=replay_buffer.num_frames() // num_parallel_environments,
+            single_deterministic_pass=True
+        )
+
+        return tf_agent.train(experience=iter(ds).get_next()[0])
+
 
     if use_tf_functions:
       # TODO(b/123828980): Enable once the cause for slowdown was identified.


### PR DESCRIPTION
This PR intends to remove the use deprecated method `gather_all` in favor of using `as_dataset` in the PPO example. 

I have to admit that I am not 100% sure that this is intended to be used this way since it is nowhere documented explicitly, but this seems logical and does not hurt training performance it seems. I'm curious to hear any feedback on this.