### PR TITLE
Update reinforce agent

### DIFF
--- a/docs/tutorials/6_reinforce_tutorial.ipynb
+++ b/docs/tutorials/6_reinforce_tutorial.ipynb
@@ -353,7 +353,7 @@
       },
       "outputs": [],
       "source": [
-        "optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate=learning_rate)\n",
+        "optimizer = tf.keras.optimizers.Adam(learning_rate=learning_rate)\n",
         "\n",
         "train_step_counter = tf.compat.v2.Variable(0)\n",
         "\n",

--- a/tf_agents/agents/reinforce/reinforce_agent.py
+++ b/tf_agents/agents/reinforce/reinforce_agent.py
@@ -289,8 +289,8 @@ class ReinforceAgent(tf_agent.TFAgent):
       eager_utils.add_gradients_summaries(grads_and_vars,
                                           self.train_step_counter)
 
-    self._optimizer.apply_gradients(
-        grads_and_vars, global_step=self.train_step_counter)
+    self._optimizer.apply_gradients(grads_and_vars)
+    self.train_step_counter.assign_add(1)
 
     return tf.nest.map_structure(tf.identity, loss_info)
 


### PR DESCRIPTION
I notice that the reinforce agent is the only one that still have the global_step
I tried and the performance are quite the same for the Adam in V1 and keras
> keras.optimizers.Adam
![Screenshot from 2021-03-18 17-07-04](https://user-images.githubusercontent.com/406131/111660557-7e9bee00-880e-11eb-9432-9894939beded.png)
> compat.v1.train.AdamOptimizer
![Screenshot from 2021-03-18 16-26-37](https://user-images.githubusercontent.com/406131/111660258-2f55bd80-880e-11eb-862d-3f7b4755221c.png)

Please tell me if this is correct or if you keep the global _step for a reason
Thanks