### PR TITLE
Modify SAC to also allow discrete actions

### DIFF
--- a/tf_agents/agents/sac/sac_agent.py
+++ b/tf_agents/agents/sac/sac_agent.py
@@ -250,12 +250,9 @@ class SacAgent(tf_agent.TFAgent):
         self.data_context, squeeze_time_dim=(train_sequence_length == 2))
 
   def _check_action_spec(self, action_spec):
-    flat_action_spec = tf.nest.flatten(action_spec)
-    for spec in flat_action_spec:
-      if spec.dtype.is_integer:
-        raise NotImplementedError(
-            'SacAgent does not currently support discrete actions. '
-            'Action spec: {}'.format(action_spec))
+    # The original SAC implementation would throw an error here if there were discrete actions,
+    # but the Hybrid variation of SAC does support discrete actions.
+    pass
 
   def _get_default_target_entropy(self, action_spec):
     # If target_entropy was not passed, set it to -dim(A)/2.0

--- a/tf_agents/networks/actor_distribution_rnn_network.py
+++ b/tf_agents/networks/actor_distribution_rnn_network.py
@@ -199,7 +199,7 @@ class ActorDistributionRnnNetwork(network.DistributionNetwork):
                                                           dtype=d_actions_distribution.dtype) if d_actions_distribution else None,
                 discrete_actions_distributions_pruned)
         else:
-            # Use logits to train.
+            # Use logits to train. 
             discrete_actions = tf.nest.map_structure(
                 lambda d_actions_distribution: tf.nn.softmax(d_actions_distribution.logits) if d_actions_distribution else None,
                 discrete_actions_distributions_pruned)

--- a/tf_agents/networks/actor_distribution_rnn_network.py
+++ b/tf_agents/networks/actor_distribution_rnn_network.py
@@ -218,7 +218,7 @@ class ActorDistributionRnnNetwork(network.DistributionNetwork):
         lambda proj_net, out_spec: proj_net(state, outer_rank, training=training)[0] if tensor_spec.is_continuous(out_spec) else None,
         self._projection_networks, self._output_tensor_spec)
 
-    # Now we have a list of discrete actions (if any) and a list of continous actions.
+    # Now we have a list of discrete actions (if any) and a list of continuous actions.
     # Next, go through the output spec and pick the right action from these two disjoint lists.
     output_actions = tf.nest.map_structure(lambda d_action, c_action, out_spec: d_action if tensor_spec.is_discrete(out_spec) else c_action,
                                            discrete_actions_distributions, continuous_actions_distributions, self._output_tensor_spec)


### PR DESCRIPTION
Modify SAC to also allow discrete actions, based on "[Discrete and Continuous Action Representation for Practical RL in Video Games](https://arxiv.org/abs/1912.11077v1)" (Delalleau, Peter, Alonso, & Logut 2019). In a forward pass, the projection networks for the discrete actions are run. During training, the results are soft-maxed, but otherwise they're turned into one-hot vectors. These discrete results are concatenated to the original state and this then goes through the other projection networks, resulting in continuous actions. Then both kinds of actions are merged and returned.

Anything that was using SAC previously should work exactly the same as before 🤞. However, the safety rails have been lifted because now it allows discrete actions, too. In a personal project I removed the 1-action limit on `ddpg/critic_network.py` but that's not in this PR.

Related: https://github.com/tensorflow/agents/issues/507

I also apologize if this totally fails some tests because I was having a hard time running unit tests on Windows. I'll come back to try again in that case.