### PR TITLE
Remove unused import in DQN tutorial

### DIFF
--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -140,7 +140,6 @@
         "import tensorflow as tf\n",
         "\n",
         "from tf_agents.agents.dqn import dqn_agent\n",
-        "from tf_agents.drivers import dynamic_step_driver\n",
         "from tf_agents.environments import suite_gym\n",
         "from tf_agents.environments import tf_py_environment\n",
         "from tf_agents.eval import metric_utils\n",
@@ -739,7 +738,8 @@
         "collect_data(train_env, random_policy, replay_buffer, initial_collect_steps)\n",
         "\n",
         "# This loop is so common in RL, that we provide standard implementations. \n",
-        "# For more details see the drivers module.\n",
+        "# For more details see tutorial 4 or the drivers module.\n",
+        "# https://github.com/tensorflow/agents/blob/master/docs/tutorials/4_drivers_tutorial.ipynb \n",
         "# https://www.tensorflow.org/agents/api_docs/python/tf_agents/drivers"
       ]
     },


### PR DESCRIPTION
As alluded to by @jan-polivka in issue #554, the import of `tf_agents.drivers.dynamic_step_driver` in the DQN tutorial is not needed.