### PR TITLE
Run apt-get update in notebook tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .idea/
 .eggs/
 *.egg-info/
+/.vs

--- a/docs/tutorials/10_checkpointer_policysaver_tutorial.ipynb
+++ b/docs/tutorials/10_checkpointer_policysaver_tutorial.ipynb
@@ -112,6 +112,7 @@
       "outputs": [],
       "source": [
         "#@test {\"skip\": true}\n",
+        "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg\n",
         "!pip install 'imageio==2.4.0'\n",
         "!pip install 'xvfbwrapper==0.2.9'\n",

--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -112,6 +112,7 @@
       },
       "outputs": [],
       "source": [
+        "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg\n",
         "!pip install 'imageio==2.4.0'\n",
         "!pip install pyvirtualdisplay\n",

--- a/docs/tutorials/6_reinforce_tutorial.ipynb
+++ b/docs/tutorials/6_reinforce_tutorial.ipynb
@@ -109,6 +109,7 @@
       },
       "outputs": [],
       "source": [
+        "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg\n",
         "!pip install 'imageio==2.4.0'\n",
         "!pip install pyvirtualdisplay\n",

--- a/docs/tutorials/7_SAC_minitaur_tutorial.ipynb
+++ b/docs/tutorials/7_SAC_minitaur_tutorial.ipynb
@@ -113,6 +113,7 @@
       },
       "outputs": [],
       "source": [
+        "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg\n",
         "!pip install 'imageio==2.4.0'\n",
         "!pip install matplotlib\n",

--- a/docs/tutorials/9_c51_tutorial.ipynb
+++ b/docs/tutorials/9_c51_tutorial.ipynb
@@ -109,6 +109,7 @@
       },
       "outputs": [],
       "source": [
+        "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg\n",
         "!pip install 'imageio==2.4.0'\n",
         "!pip install pyvirtualdisplay\n",


### PR DESCRIPTION
Notebooks run apt-get update to update the xvfb ffmpeg to the version required to run in the tutorials in the Google Colab, as discussed in [PR590](https://github.com/tensorflow/agents/pull/590).