### PR TITLE
environments/gym_wrapper forward reward_range from GymEnv to PyEnviro…

### DIFF
--- a/tf_agents/environments/gym_wrapper.py
+++ b/tf_agents/environments/gym_wrapper.py
@@ -165,6 +165,8 @@ class GymWrapper(py_environment.PyEnvironment):
     self._action_spec = spec_from_gym_space(self._gym_env.action_space,
                                             spec_dtype_map, simplify_box_bounds,
                                             'action')
+    self._reward_spec = specs.BoundedArraySpec(
+        shape=(), dtype=np.float64, minimum=gym_env.reward_range[0], maximum=gym_env.reward_range[1], name='reward')
     self._flat_obs_spec = tf.nest.flatten(self._observation_spec)
     self._render_kwargs = render_kwargs or {}
     self._info = None
@@ -247,6 +249,9 @@ class GymWrapper(py_environment.PyEnvironment):
 
   def action_spec(self) -> types.NestedArraySpec:
     return self._action_spec
+
+  def reward_spec(self) -> types.NestedArraySpec:
+    return self._reward_spec
 
   def close(self) -> None:
     return self._gym_env.close()

--- a/tf_agents/environments/gym_wrapper.py
+++ b/tf_agents/environments/gym_wrapper.py
@@ -165,8 +165,11 @@ class GymWrapper(py_environment.PyEnvironment):
     self._action_spec = spec_from_gym_space(self._gym_env.action_space,
                                             spec_dtype_map, simplify_box_bounds,
                                             'action')
-    self._reward_spec = specs.BoundedArraySpec(
-        shape=(), dtype=np.float64, minimum=gym_env.reward_range[0], maximum=gym_env.reward_range[1], name='reward')
+    self._reward_spec = specs.BoundedArraySpec(shape=(),
+                                              dtype=np.float64,
+                                              minimum=gym_env.reward_range[0],
+                                              maximum=gym_env.reward_range[1],
+                                              name='reward')
     self._flat_obs_spec = tf.nest.flatten(self._observation_spec)
     self._render_kwargs = render_kwargs or {}
     self._info = None

--- a/tf_agents/environments/gym_wrapper_test.py
+++ b/tf_agents/environments/gym_wrapper_test.py
@@ -436,6 +436,13 @@ class GymWrapperOnCartpoleTest(test_utils.TestCase):
     time_step = env.reset()
     self.assertEqual(env.observation_spec().dtype, time_step.observation.dtype)
 
+  def test_reward_range(self):
+    cartpole_env = gym.spec('CartPole-v1').make()
+    cartpole_env.reward_range = (-3.0, 5.0)
+    env = gym_wrapper.GymWrapper(cartpole_env)
+    self.assertEqual(env.reward_spec().minimum, -3.0)
+    self.assertEqual(env.reward_spec().maximum, 5.0)
+
 
 if __name__ == '__main__':
   test_utils.main()


### PR DESCRIPTION
The GymEnv defines a reward_range. This CL forwards reward_range in GymWrapper. Usefull for some algorithms instead of -inf;+inf default range