### PR TITLE
Fix syntax error in rate_limiter definition

### DIFF
--- a/docs/tutorials/7_SAC_minitaur_tutorial.ipynb
+++ b/docs/tutorials/7_SAC_minitaur_tutorial.ipynb
@@ -512,7 +512,7 @@
         "\n",
         "In this tutorial, this is less important than `max_size` -- but in a distributed setting with async collection and training, you will probably want to experiment with `rate_limiters.SampleToInsertRatio`, using a samples_per_insert somewhere between 2 and 1000. For example:\n",
         "```\n",
-        "rate_limiter=reverb.rate_limiters.SampleToInsertRatio(samples_per_insert=3.0, min_size_to_sample=3, error_buffer=3.0))\n",
+        "rate_limiter=reverb.rate_limiters.SampleToInsertRatio(samples_per_insert=3.0, min_size_to_sample=3, error_buffer=3.0)\n",
         "```\n",
         "\n",
         "\n"


### PR DESCRIPTION
Minor syntax error: unbalanced brackets.