### PR TITLE
Minor typo in array_specs

### DIFF
--- a/tf_agents/specs/array_spec.py
+++ b/tf_agents/specs/array_spec.py
@@ -33,7 +33,7 @@ def sample_bounded_spec(spec, rng):
     rng: A numpy RandomState to use for the sampling.
 
   Returns:
-    An np.array sample of the requested space.
+    An np.array sample of the requested spec.
   """
   tf_dtype = tf.as_dtype(spec.dtype)
   low = spec.minimum


### PR DESCRIPTION
Hi,
noticed this minor typo in the documentation of `sample_bounded_spec`

Not 100% sure it actually is one. But space seems very out of place in this context. And spec describes the functionallity better.