### PR TITLE
Fix a typo in README: "Use this tag get" -> "Use this to get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ documentation for the release is on
 ```shell
 $ pip install --user tf-agents[reverb]
 
-# Use this tag get the matching examples and colabs.
+# Use this to get the matching examples and colabs.
 $ git clone https://github.com/tensorflow/agents.git
 $ cd agents
 $ git checkout v0.11.0


### PR DESCRIPTION
This PR fixes a typo in the installation instructions ("Use this tag get the matching examples and colabs" becomes "Use this to get the matching examples and colabs"). The typo was introduced in 1d76efbde