### PR TITLE
Ensure all time_step functions respect provided reward(_spec)

### DIFF
--- a/tf_agents/trajectories/time_step.py
+++ b/tf_agents/trajectories/time_step.py
@@ -48,12 +48,8 @@ def _get_np_dtype(spec):
   if isinstance(dtype, tf.dtypes.DType):
     dtype = dtype.as_numpy_dtype
   return np.dtype(dtype)
-  
-# def _get_np_dtype(spec):
-#   if type(spec) == tensor_spec.TensorSpec:
-#     return spec.dtype.as_numpy_dtype
-#   elif type(spec) == array_spec.ArraySpec:
-#     return spec.dtype
+
+
 class TimeStep(
     NamedTuple('TimeStep', [('step_type', types.SpecTensorOrArray),
                             ('reward', types.NestedSpecTensorOrArray),

--- a/tf_agents/trajectories/time_step.py
+++ b/tf_agents/trajectories/time_step.py
@@ -23,7 +23,6 @@ import pprint
 from typing import NamedTuple, Optional
 
 import numpy as np
-from pandas import array
 import tensorflow as tf
 
 from tf_agents.specs import array_spec
@@ -46,7 +45,7 @@ def _get_np_dtype(spec):
     return None
   dtype = spec.dtype
   if isinstance(dtype, tf.dtypes.DType):
-    dtype = dtype.as_numpy_dtype
+    dtype = dtype.as_numpy_dtype()
   return np.dtype(dtype)
 
 

--- a/tf_agents/trajectories/time_step_test.py
+++ b/tf_agents/trajectories/time_step_test.py
@@ -50,7 +50,7 @@ class TimeStepTest(tf.test.TestCase):
   def testRestartRewardDTypeTensor(self):
     observation = -1
     observation_batch = tf.random.uniform([5,2])
-    reward_spec = tensor_spec.TensorSpec(shape=[], dtype=tf.int64)
+    reward_spec = tensor_spec.TensorSpec(shape=[], dtype=tf.float64)
     time_step = ts.restart(observation, None, reward_spec).reward
     time_step_batch = ts.restart(observation_batch, 5, reward_spec).reward
 
@@ -59,13 +59,13 @@ class TimeStepTest(tf.test.TestCase):
 
   def testTransition(self):
     observation = -1
-    reward = np.int64(2)
+    reward = 2.0
     discount = 1.0
     time_step = ts.transition(observation, reward, discount)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.MID, time_step.step_type)
     self.assertEqual(-1, time_step.observation)
-    self.assertEqual(2, time_step.reward)
+    self.assertEqual(2.0, time_step.reward)
     self.assertEqual(1.0, time_step.discount)
 
   def testTransitionRewardDTypeTensor(self):
@@ -78,7 +78,7 @@ class TimeStepTest(tf.test.TestCase):
 
   def testTermination(self):
     observation = -1
-    reward = tf.float64(2.0)
+    reward = 2.0
     time_step = ts.termination(observation, reward)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.LAST, time_step.step_type)
@@ -95,13 +95,13 @@ class TimeStepTest(tf.test.TestCase):
 
   def testTruncation(self):
     observation = -1
-    reward = tf.constant(2, dtype=tf.float32)
+    reward = 2.0
     discount = 1.0
     time_step = ts.truncation(observation, reward, discount)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.LAST, time_step.step_type)
     self.assertEqual(-1, time_step.observation)
-    self.assertEqual(2, time_step.reward)
+    self.assertEqual(2.0, time_step.reward)
     self.assertEqual(1.0, time_step.discount)
 
   def testTruncationRewardDTypeTensor(self):

--- a/tf_agents/trajectories/time_step_test.py
+++ b/tf_agents/trajectories/time_step_test.py
@@ -36,21 +36,49 @@ class TimeStepTest(tf.test.TestCase):
     self.assertEqual(-1, time_step.observation)
     self.assertEqual(0.0, time_step.reward)
     self.assertEqual(1.0, time_step.discount)
+  
+  def testRestartRewardDTypeArray(self):
+    observation = -1
+    observation_batch = tf.random.uniform([5,2])
+    reward_spec = array_spec.ArraySpec(shape=[], dtype=np.float16)
+    time_step = ts.restart(observation, None, reward_spec).reward
+    time_step_batch = ts.restart(observation_batch, 5, reward_spec).reward
+
+    self.assertEqual(time_step.dtype, reward_spec.dtype)
+    self.assertEqual(time_step_batch.dtype, reward_spec.dtype)
+
+  def testRestartRewardDTypeTensor(self):
+    observation = -1
+    observation_batch = tf.random.uniform([5,2])
+    reward_spec = tensor_spec.TensorSpec(shape=[], dtype=tf.int64)
+    time_step = ts.restart(observation, None, reward_spec).reward
+    time_step_batch = ts.restart(observation_batch, 5, reward_spec).reward
+
+    self.assertEqual(time_step.dtype, reward_spec.dtype)
+    self.assertEqual(time_step_batch.dtype, reward_spec.dtype)
 
   def testTransition(self):
     observation = -1
-    reward = 2.0
+    reward = np.int64(2)
     discount = 1.0
     time_step = ts.transition(observation, reward, discount)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.MID, time_step.step_type)
     self.assertEqual(-1, time_step.observation)
-    self.assertEqual(2.0, time_step.reward)
+    self.assertEqual(2, time_step.reward)
     self.assertEqual(1.0, time_step.discount)
+
+  def testTransitionRewardDTypeTensor(self):
+    observation = tf.random.uniform([5,2])
+    reward = tf.random.uniform([2], dtype=tf.float64)
+    discount = 1.0
+    time_step = ts.transition(observation, reward, discount)
+
+    self.assertEqual(time_step.reward.dtype, reward.dtype)
 
   def testTermination(self):
     observation = -1
-    reward = 2.0
+    reward = tf.float64(2.0)
     time_step = ts.termination(observation, reward)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.LAST, time_step.step_type)
@@ -58,16 +86,31 @@ class TimeStepTest(tf.test.TestCase):
     self.assertEqual(2.0, time_step.reward)
     self.assertEqual(0.0, time_step.discount)
 
+  def testTerminationRewardDTypeTensor(self):
+    observation = tf.random.uniform([5,2])
+    reward = tf.random.uniform([2], dtype=tf.float16)
+    time_step = ts.termination(observation, reward)
+
+    self.assertEqual(time_step.reward.dtype, reward.dtype)
+
   def testTruncation(self):
     observation = -1
-    reward = 2.0
+    reward = tf.constant(2, dtype=tf.float32)
     discount = 1.0
     time_step = ts.truncation(observation, reward, discount)  # pytype: disable=wrong-arg-types
 
     self.assertEqual(ts.StepType.LAST, time_step.step_type)
     self.assertEqual(-1, time_step.observation)
-    self.assertEqual(2.0, time_step.reward)
+    self.assertEqual(2, time_step.reward)
     self.assertEqual(1.0, time_step.discount)
+
+  def testTruncationRewardDTypeTensor(self):
+    observation = tf.random.uniform([5,2])
+    reward = tf.random.uniform([2], dtype=tf.float64)
+    discount = 1.0
+    time_step = ts.truncation(observation, reward, discount)
+
+    self.assertEqual(time_step.reward.dtype, reward.dtype)
 
   def testRestartIsFirst(self):
     observation = -1


### PR DESCRIPTION
This PR aims to address the issue described in #704
The implementation includes:
- change `_as_float32_array` to `_as_array` that accepts optional `type` parameter
- implement `_as_array` to functions `ts.restart`, `ts.transition`, `ts.termination` and `ts.truncation`
- extend unit tests