### PR TITLE
Support TFEnvironment in Actor

### DIFF
--- a/tf_agents/train/actor.py
+++ b/tf_agents/train/actor.py
@@ -122,7 +122,13 @@ class Actor(object):
           max_steps=steps_per_run,
           max_episodes=episodes_per_run)
     elif isinstance(env, tf_environment.TFEnvironment):
-      raise ValueError("Actor doesn't support TFEnvironments yet.")
+      self._driver = tf_driver.TFDriver(
+          env,
+          policy,
+          self._observers,
+          transition_observers=self._transition_observers,
+          max_steps=steps_per_run,
+          max_episodes=episodes_per_run)
     else:
       raise ValueError("Unknown environment type.")
 


### PR DESCRIPTION
When using Actor to wrap a collecting policy on a TFEnvironment, I came across the exception "ValueError("Actor doesn't support TFEnvironments yet.")" and I found it easy to solve as long as to use TFDriver with the same arguments as the PyDriver, which drives the policy on a PyEnvironment.