### PR TITLE
Bias Layer: Add support for regularizer and constraint

### DIFF
--- a/tf_agents/keras_layers/bias_layer.py
+++ b/tf_agents/keras_layers/bias_layer.py
@@ -37,7 +37,10 @@ class BiasLayer(tf.keras.layers.Layer):
         shape `(batch_size, input_dim)`.
   """
 
-  def __init__(self, bias_initializer='zeros', bias_regularizer=None, bias_constraint=None, **kwargs):
+  def __init__(self, bias_initializer='zeros', 
+                     bias_regularizer=None, 
+                     bias_constraint=None, 
+                     **kwargs):
     if 'input_shape' not in kwargs and 'input_dim' in kwargs:
       kwargs['input_shape'] = (kwargs.pop('input_dim'),)
 

--- a/tf_agents/keras_layers/bias_layer.py
+++ b/tf_agents/keras_layers/bias_layer.py
@@ -23,10 +23,8 @@ import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
 class BiasLayer(tf.keras.layers.Layer):
   """Keras layer that only adds a bias to the input.
-
   `BiasLayer` implements the operation:
   `output = input + bias`
-
   Args:
       bias_initializer: Initializer for the bias vector.
   Input shape:
@@ -39,12 +37,14 @@ class BiasLayer(tf.keras.layers.Layer):
         shape `(batch_size, input_dim)`.
   """
 
-  def __init__(self, bias_initializer='zeros', **kwargs):
+  def __init__(self, bias_initializer='zeros', bias_regularizer=None, bias_constraint=None, **kwargs):
     if 'input_shape' not in kwargs and 'input_dim' in kwargs:
       kwargs['input_shape'] = (kwargs.pop('input_dim'),)
 
     super(BiasLayer, self).__init__(**kwargs)
     self.bias_initializer = tf.keras.initializers.get(bias_initializer)
+    self.bias_regularizer = tf.keras.regularizers.get(bias_regularizer)
+    self.bias_constraint = tf.keras.constraints.get(bias_constraint)
 
     self.supports_masking = True
 
@@ -59,6 +59,8 @@ class BiasLayer(tf.keras.layers.Layer):
         'bias',
         shape=shape,
         initializer=self.bias_initializer,
+        regularizer=self.bias_regularizer,
+        constraint=self.bias_constraint,
         dtype=self.dtype,
         trainable=True)
     self.built = True


### PR DESCRIPTION
Small patch to add the bias_regularizer and bias_constraint. It is needed to be like other layers in TF2.0.
They are initialized as None based on current master.

