### PR TITLE
Optimise linear bandits for large batch size

### DIFF
--- a/tf_agents/bandits/agents/linear_bandit_agent.py
+++ b/tf_agents/bandits/agents/linear_bandit_agent.py
@@ -620,12 +620,11 @@ class LinearBanditAgent(tf_agent.TFAgent):
     observation, reward = self._maybe_apply_per_example_weight(
         experience_observation, experience_reward, weights)
     for k in range(self._num_models):
-      diag_mask = tf.linalg.tensor_diag(
-          tf.cast(tf.equal(action, k), self._dtype))
-      observations_for_arm = tf.matmul(diag_mask, observation)
-      rewards_for_arm = tf.matmul(diag_mask, tf.reshape(reward, [-1, 1]))
+      action_mask = tf.equal(action, k)
+      observations_for_arm = tf.boolean_mask(observation, action_mask, axis=0)
+      rewards_for_arm = tf.boolean_mask(tf.reshape(reward, [-1, 1]), action_mask, axis=0)
 
-      num_samples_for_arm_current = tf.reduce_sum(diag_mask)
+      num_samples_for_arm_current = tf.reduce_sum(tf.cast(action_mask, self._dtype))
       tf.compat.v1.assign_add(self._num_samples_list[k],
                               num_samples_for_arm_current)
       num_samples_for_arm_total = self._num_samples_list[k].read_value()

--- a/tf_agents/bandits/policies/linalg.py
+++ b/tf_agents/bandits/policies/linalg.py
@@ -75,12 +75,11 @@ def conjugate_gradient(a_mat: types.Tensor,
         tf.expand_dims(active_columns_mask, axis=0),
         multiples=[tf.shape(b_mat)[0], 1])
     a_x_p = tf.matmul(a_mat, p)
-    alpha_diag = tf.linalg.diag(rs_old / tf.reduce_sum(p * a_x_p, axis=0))
-    x = tf.where(active_columns_tiled_mask, x + tf.matmul(p, alpha_diag), x)
-    r = tf.where(active_columns_tiled_mask, r - tf.matmul(a_x_p, alpha_diag), r)
+    alpha = rs_old / tf.reduce_sum(p * a_x_p, axis=0)
+    x = tf.where(active_columns_tiled_mask, x + tf.multiply(p, alpha), x)
+    r = tf.where(active_columns_tiled_mask, r - tf.multiply(a_x_p, alpha), r)
     rs_new = tf.where(active_columns_mask, tf.einsum('ij,ij->j', r, r), rs_new)
-    p = tf.where(active_columns_tiled_mask,
-                 r + tf.matmul(p, tf.linalg.diag(rs_new / rs_old)), p)
+    p = tf.where(active_columns_tiled_mask, r + tf.multiply(p, rs_new / rs_old), p)
     rs_old = tf.where(active_columns_mask, rs_new, rs_old)
     i = i + 1
     return i, x, p, r, rs_old, rs_new


### PR DESCRIPTION
Hello everyone!
We've been lately experimenting with linear bandits and encounter several obstacles when using a larger batch size.

In our use case, we have a sizeable dataset that we want to pre-train the bandit on and to make it faster we tried to increase the size of the batches processed by the agent and its policy. During these experiments, we realised that the performance is actually degrading with larger batch sizes and soon we got hit by OOM.

We have found out, that these bottlenecks are caused by creating very large matrices (up to the shape `[batch_size, batch_size]`) in:
- `linear_bandit._train()` - `diag_mask`
    - this was the source of the OOM error 
https://github.com/tensorflow/agents/blob/dbc75999c85bbc88028c0ea8803cebdfd6c56a9b/tf_agents/bandits/agents/linear_bandit_agent.py#L622-L626

- `conjugate_gradient()` - `alpha_diag`
    - this was the cause of degraded performance
https://github.com/tensorflow/agents/blob/dbc75999c85bbc88028c0ea8803cebdfd6c56a9b/tf_agents/bandits/policies/linalg.py#L78-L84

With this PR I am proposing the patches we have used for our experiment, but of course, I'm happy to adjust them if you have other ideas on how to (e.g. using einsum).

Best regards,
Michal