### PR TITLE
[Minor Code Fix] Update 3_policies_tutorial.ipynb

### DIFF
--- a/docs/tutorials/3_policies_tutorial.ipynb
+++ b/docs/tutorials/3_policies_tutorial.ipynb
@@ -418,7 +418,7 @@
         "    self._output_tensor_spec = output_tensor_spec\n",
         "    self._sub_layers = [\n",
         "        tf.keras.layers.Dense(\n",
-        "            action_spec.shape.num_elements(), activation=tf.nn.tanh),\n",
+        "            self._output_tensor_spec.shape.num_elements(), activation=tf.nn.tanh),\n",
         "    ]\n",
         "\n",
         "  def call(self, observations, step_type, network_state):\n",


### PR DESCRIPTION
In the section `TensorFlow Policies`/`Example 2: Actor Policy`, in the codes of defining a `Action Network` as belows:

```python
class ActionNet(network.Network):

  def __init__(self, input_tensor_spec, output_tensor_spec):
    super(ActionNet, self).__init__(
        input_tensor_spec=input_tensor_spec,
        state_spec=(),
        name='ActionNet')
    self._output_tensor_spec = output_tensor_spec
    self._sub_layers = [
        tf.keras.layers.Dense(
            action_spec.shape.num_elements(), activation=tf.nn.tanh),
    ]

  def call(self, observations, step_type, network_state):
    del step_type

    output = tf.cast(observations, dtype=tf.float32)
    for layer in self._sub_layers:
      output = layer(output)
    actions = tf.reshape(output, [-1] + self._output_tensor_spec.shape.as_list())

    # Scale and shift actions to the correct range if necessary.
    return actions, network_state
```

The code block in `__init__()` for defining the `Dense` layer, it used a outer scope variable `action_spec` instead of the init parameter `output_tensor_spec`. I recommends to change this to fix the bug.