### PR TITLE
Fix reduce_retracing error in tutorial 2 on colab

### DIFF
--- a/docs/tutorials/2_environments_tutorial.ipynb
+++ b/docs/tutorials/2_environments_tutorial.ipynb
@@ -110,7 +110,7 @@
       "outputs": [],
       "source": [
         "!pip install \"gym>=0.21.0\"\n",
-        "!pip install tf-agents\n"
+        "!pip install tf-agents[reverb]\n"
       ]
     },
     {


### PR DESCRIPTION
When trying to run tutorial 2 in colab, I got the error

```
TypeError: function() got an unexpected keyword argument 'reduce_retracing'`
```

This PR implements the resolution suggested in https://github.com/tensorflow/agents/issues/747, which works for me.