### PR TITLE
Allow passing conv_type from ActionDistributionNetwork to EncodingNetwork

### DIFF
--- a/tf_agents/version.py
+++ b/tf_agents/version.py
@@ -26,7 +26,7 @@ _PATCH_VERSION = '0'
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
 _DEV_SUFFIX = 'dev'
-_REL_SUFFIX = 'rc1'
+_REL_SUFFIX = ''
 
 # Example, '0.10.0rc0'
 __version__ = '.'.join([

--- a/tf_agents/version.py
+++ b/tf_agents/version.py
@@ -26,7 +26,7 @@ _PATCH_VERSION = '0'
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
 _DEV_SUFFIX = 'dev'
-_REL_SUFFIX = 'rc0'
+_REL_SUFFIX = 'rc1'
 
 # Example, '0.10.0rc0'
 __version__ = '.'.join([


### PR DESCRIPTION
EncodingNetwork currently allows 1D convolutions. However, the ActionDistributionNetwork class does not allow you to pass CONV_TYPE_1D to the parameter "conv_type" of the encoding network.