### PR TITLE
Fix time_step, trajectory format for tf.print

### DIFF
--- a/tf_agents/trajectories/time_step.py
+++ b/tf_agents/trajectories/time_step.py
@@ -95,8 +95,11 @@ class TimeStep(
     return hash(tuple(tf.nest.flatten(self)))
 
   def __repr__(self):
-    return 'TimeStep(\n' + \
-      pprint.pformat(dict(self._asdict()), sort_dicts=False) + ')'
+    return (
+        'TimeStep(\n'
+        + pprint.pformat(dict(self._asdict()), sort_dicts=False)
+        + ')'
+    )
 
 
 class StepType(object):

--- a/tf_agents/trajectories/time_step.py
+++ b/tf_agents/trajectories/time_step.py
@@ -95,7 +95,8 @@ class TimeStep(
     return hash(tuple(tf.nest.flatten(self)))
 
   def __repr__(self):
-    return 'TimeStep(\n' + pprint.pformat(dict(self._asdict())) + ')'
+    return 'TimeStep(\n' + \
+      pprint.pformat(dict(self._asdict()), sort_dicts=False) + ')'
 
 
 class StepType(object):

--- a/tf_agents/trajectories/time_step_test.py
+++ b/tf_agents/trajectories/time_step_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
+
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 from tf_agents.specs import array_spec
@@ -448,6 +450,18 @@ class TFTimeStepTest(tf.test.TestCase):
     reward = (None, None)
     with self.assertRaises(ValueError):
       ts.transition(observation, reward)  # pytype: disable=wrong-arg-types
+
+  def testPrintFormat(self):
+    observation = tf.constant(-1)
+    reward = tf.constant(2.0)
+
+    time_step = ts.transition(observation, reward)
+    with self.captureWritesToStream(sys.stdout) as printed:
+      print_op = tf.print(time_step, output_stream=sys.stdout)
+      self.evaluate(print_op)
+
+    expected = "{'step_type': 1, 'reward': 2, 'discount': 1, 'observation': -1}"
+    self.assertIn(expected, printed.contents())
 
 
 class TFTimeStepSpecTest(tf.test.TestCase):

--- a/tf_agents/trajectories/trajectory.py
+++ b/tf_agents/trajectories/trajectory.py
@@ -111,8 +111,11 @@ class Trajectory(
     return self._replace(**kwargs)
 
   def __repr__(self):
-    return 'Trajectory(\n' + \
-      pprint.pformat(dict(self._asdict()), sort_dicts=False) + ')'
+    return (
+        'Trajectory(\n'
+        + print.pformat(dict(self._asdict()), sort_dicts=False)
+        + ')'
+    )
 
 
 # TODO(b/162101981): Move to its own file.

--- a/tf_agents/trajectories/trajectory.py
+++ b/tf_agents/trajectories/trajectory.py
@@ -113,7 +113,7 @@ class Trajectory(
   def __repr__(self):
     return (
         'Trajectory(\n'
-        + print.pformat(dict(self._asdict()), sort_dicts=False)
+        + pprint.pformat(dict(self._asdict()), sort_dicts=False)
         + ')'
     )
 

--- a/tf_agents/trajectories/trajectory.py
+++ b/tf_agents/trajectories/trajectory.py
@@ -111,7 +111,8 @@ class Trajectory(
     return self._replace(**kwargs)
 
   def __repr__(self):
-    return 'Trajectory(\n' + pprint.pformat(dict(self._asdict())) + ')'
+    return 'Trajectory(\n' + \
+      pprint.pformat(dict(self._asdict()), sort_dicts=False) + ')'
 
 
 # TODO(b/162101981): Move to its own file.

--- a/tf_agents/trajectories/trajectory_test.py
+++ b/tf_agents/trajectories/trajectory_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
+
 import numpy as np
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
 
@@ -124,6 +126,21 @@ class TrajectoryTest(test_utils.TestCase):
     self.assertFalse(tf.is_tensor(traj.step_type))
     self.assertAllEqual(traj.step_type, [ts.StepType.FIRST] * 3)
     self.assertAllEqual(traj.next_step_type, [ts.StepType.LAST] * 3)
+
+  def testPrintFormat(self):
+    observation = ()
+    action = ()
+    policy_info = ()
+    reward = tf.constant([2.0, 2.0, 2.0])
+    discount = tf.constant([0.9, 0.9, 0.9])
+
+    traj = trajectory.first(observation, action, policy_info, reward, discount)
+    with self.captureWritesToStream(sys.stdout) as printed:
+      print_op = tf.print(traj, output_stream=sys.stdout)
+      self.evaluate(print_op)
+
+    expected = "'discount': [0.9 0.9 0.9]"
+    self.assertIn(expected, printed.contents())
 
   def testFromEpisodeTensor(self):
     observation = tf.random.uniform((4, 5))


### PR DESCRIPTION
Addresses #784.
Note, this requires `python >= 3.8`, so should probably be put on ice until a release requires 3.8.

Open to suggestions, as this approach will cause fields of `TimeStep` and `Trajectory` to no longer be printed in sorted order.
`Transition` is not affected here because the values of its fields are not `Tensor` objects, rather `PolicyStep` and `TimeStep` objects.