### PR TITLE
Documentation: Fix broken Deep Q Network with TFA build

### DIFF
--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -114,10 +114,7 @@
       "source": [
         "!sudo apt-get update\n",
         "!sudo apt-get install -y xvfb ffmpeg freeglut3-dev\n",
-        "!pip install 'imageio==2.4.0'\n",
-        "!pip install pyvirtualdisplay\n",
-        "!pip install tf-agents[reverb]\n",
-        "!pip install pyglet"
+        "!pip install -U -qq 'imageio==2.4.0' pyvirtualdisplay tf-agents[reverb] pyglet tensorflow"
       ]
     },
     {


### PR DESCRIPTION
- Upgrades TF to 2.11 (Colab uses 2.9.2), upgrades other dependencies (PiPy) just in case.

```
!pip install -U -qq 'imageio==2.4.0' pyvirtualdisplay tf-agents[reverb] pyglet tensorflow
```

Without this fix, you get:

```
RuntimeError                              Traceback (most recent call last)
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xe
```

after attempting to import the necessary libraries.

@tfboyd @MarkDaoust PTAL