### PR TITLE
Updating pygame requirement for Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ def get_required_packages():
       # Used by gym >= 0.22.0. Only installed as a dependency when gym[all] is
       # installed or if gym[*] (where * is an environment which lists pygame as
       # a dependency).
-      'pygame == 2.1.0',
+      'pygame == 2.1.3',
   ]
   add_additional_packages(required_packages)
   return required_packages


### PR DESCRIPTION
Currently, tf-agents and tf-agents cannot be installed for Python 3.11 due to an outdated pygame version. Updating the requirement to pygame=2.1.3 allows tf-agents to be installed on Python 3.11. 