### PR TITLE
Upgrade numpy version in  1_dqn_tutorial.ipynb

### DIFF
--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -122,6 +122,14 @@
     },
     {
       "cell_type": "code",
+      "outputs": [],
+      "source": [
+      
+        "!pip install numpy --upgrade"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
       "metadata": {
         "id": "sMitx5qSgJk1"


### PR DESCRIPTION
Added a code cell to upgrade numpy version because while importing the libraries facing an error: `module compiled against API version 0x10 but this version of numpy is 0xf`. Upgrading the numpy version resolves the error.