### PR TITLE
Adding episodic_replay_buffer to __init__.py file

### DIFF
--- a/tf_agents/replay_buffers/__init__.py
+++ b/tf_agents/replay_buffers/__init__.py
@@ -15,6 +15,7 @@
 
 """Replay Buffers Module."""
 
+from tf_agents.replay_buffers import episodic_replay_buffer
 from tf_agents.replay_buffers import py_hashed_replay_buffer
 from tf_agents.replay_buffers import py_uniform_replay_buffer
 from tf_agents.replay_buffers import replay_buffer


### PR DESCRIPTION
Since __init__.py has been filled with specific replay buffers, the episodic_replay_buffer needs to be imported separately, breaking my code. This fixes the issue, but let me know if it was intended. 