### PR TITLE
Fix test assertion in wrappers_test.py

### DIFF
--- a/tf_agents/environments/wrappers_test.py
+++ b/tf_agents/environments/wrappers_test.py
@@ -289,7 +289,7 @@ class FixedLengthWrapperTest(test_utils.TestCase):
         time_step = env.step(np.array(1, dtype=np.int32))
         num_steps += 1
       # Verify episode length.
-      self.assertTrue(num_steps, env.fix_length)
+      self.assertEqual(num_steps, env.fix_length)
 
       # it should automatically reset.
       self.assertTrue(time_step.is_first())


### PR DESCRIPTION
Replace call to `assertTrue` with `assertEqual`. As originally written, the call to `assertTrue` does not verify episode length, just that it has a truthy value.