### PR TITLE
Add seed, get_state, and set_state to BatchedPyEnvironment.

### DIFF
--- a/tf_agents/environments/batched_py_environment.py
+++ b/tf_agents/environments/batched_py_environment.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 from multiprocessing import dummy as mp_threads
 from multiprocessing import pool
 # pylint: enable=line-too-long
-from typing import Sequence, Optional
+from typing import Any, Optional, Sequence
 
 import gin
 import tensorflow as tf  # pylint: disable=g-explicit-tensorflow-version-import
@@ -181,6 +181,25 @@ class BatchedPyEnvironment(py_environment.PyEnvironment):
           zip(self._envs, unstacked_actions),
       )
       return nest_utils.stack_nested_arrays(time_steps)
+
+  def seed(self, seed: types.Seed) -> Any:
+    """Seeds the environment.
+
+    Args:
+      seed: Value to use as seed for the environment.
+    """
+    return self._execute(lambda env: env.seed(seed), self._envs)
+
+  def get_state(self) -> Any:
+    """Returns the `state` of the environment."""
+    return self._execute(lambda env: env.get_state(), self._envs)
+
+  def set_state(self, state: Sequence[Any]) -> None:
+    """Restores the environment to a given `state`."""
+    self._execute(
+      lambda env_and_state: env_and_state[0].set_state(env_and_state[1]),
+      zip(self._envs, state)
+    )
 
   def render(self, mode="rgb_array") -> Optional[types.NestedArray]:
     if self._num_envs == 1:

--- a/tf_agents/environments/batched_py_environment.py
+++ b/tf_agents/environments/batched_py_environment.py
@@ -183,11 +183,7 @@ class BatchedPyEnvironment(py_environment.PyEnvironment):
       return nest_utils.stack_nested_arrays(time_steps)
 
   def seed(self, seed: types.Seed) -> Any:
-    """Seeds the environment.
-
-    Args:
-      seed: Value to use as seed for the environment.
-    """
+    """Seeds the environment."""
     return self._execute(lambda env: env.seed(seed), self._envs)
 
   def get_state(self) -> Any:
@@ -197,8 +193,8 @@ class BatchedPyEnvironment(py_environment.PyEnvironment):
   def set_state(self, state: Sequence[Any]) -> None:
     """Restores the environment to a given `state`."""
     self._execute(
-      lambda env_and_state: env_and_state[0].set_state(env_and_state[1]),
-      zip(self._envs, state)
+        lambda env_state: env_state[0].set_state(env_state[1]),
+        zip(self._envs, state)
     )
 
   def render(self, mode="rgb_array") -> Optional[types.NestedArray]:

--- a/tf_agents/environments/batched_py_environment_test.py
+++ b/tf_agents/environments/batched_py_environment_test.py
@@ -38,9 +38,20 @@ class GymWrapperEnvironmentMock(random_py_environment.RandomPyEnvironment):
   def __init__(self, *args, **kwargs):
     super(GymWrapperEnvironmentMock, self).__init__(*args, **kwargs)
     self._info = {}
+    self._state = {'seed': 0}
 
   def get_info(self):
     return self._info
+
+  def seed(self, seed):
+    self._state['seed'] = seed
+    return super(GymWrapperEnvironmentMock, self).seed(seed)
+
+  def get_state(self):
+    return self._state
+
+  def set_state(self, state):
+    self._state = state
 
   def _step(self, action):
     self._info['last_action'] = action
@@ -114,6 +125,34 @@ class BatchedPyEnvironmentTest(tf.test.TestCase, parameterized.TestCase):
     gym_env.step(action)
     info = gym_env.get_info()
     self.assertAllEqual(info['last_action'], action)
+    gym_env.close()
+
+  @parameterized.parameters(*COMMON_PARAMETERS)
+  def test_seed_gym_env(self, multithreading):
+    num_envs = 5
+    rng = np.random.RandomState()
+    gym_env = self._make_batched_mock_gym_py_environment(
+        multithreading, num_envs=num_envs
+    )
+
+    gym_env.seed(42)
+
+    actual_seeds = [state['seed'] for state in gym_env.get_state()]
+    self.assertEqual(actual_seeds, [42] * num_envs)
+    gym_env.close()
+
+  @parameterized.parameters(*COMMON_PARAMETERS)
+  def test_state_gym_env(self, multithreading):
+    num_envs = 5
+    rng = np.random.RandomState()
+    gym_env = self._make_batched_mock_gym_py_environment(
+        multithreading, num_envs=num_envs
+    )
+    state = [{'value': i * 10} for i in range(num_envs)]
+
+    gym_env.set_state(state)
+
+    self.assertEqual(gym_env.get_state(), state)
     gym_env.close()
 
   @parameterized.parameters(*COMMON_PARAMETERS)

--- a/tf_agents/environments/batched_py_environment_test.py
+++ b/tf_agents/environments/batched_py_environment_test.py
@@ -130,7 +130,6 @@ class BatchedPyEnvironmentTest(tf.test.TestCase, parameterized.TestCase):
   @parameterized.parameters(*COMMON_PARAMETERS)
   def test_seed_gym_env(self, multithreading):
     num_envs = 5
-    rng = np.random.RandomState()
     gym_env = self._make_batched_mock_gym_py_environment(
         multithreading, num_envs=num_envs
     )
@@ -144,7 +143,6 @@ class BatchedPyEnvironmentTest(tf.test.TestCase, parameterized.TestCase):
   @parameterized.parameters(*COMMON_PARAMETERS)
   def test_state_gym_env(self, multithreading):
     num_envs = 5
-    rng = np.random.RandomState()
     gym_env = self._make_batched_mock_gym_py_environment(
         multithreading, num_envs=num_envs
     )


### PR DESCRIPTION
Fixes #587 by executing the underlying env's methods.

BatchedPyEnvironment now supports all the methods from PyEnvironment.