### PR TITLE
docs: DQN tutorial — clarify Driver pattern and link to Drivers tutorial/API

### DIFF
--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -39,26 +39,26 @@
       "source": [
         "# Train a Deep Q Network with TF-Agents\n",
         "\n",
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/agents/tutorials/1_dqn_tutorial\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003e\n",
-        "    View on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/agents/blob/master/docs/tutorials/1_dqn_tutorial.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003e\n",
-        "    Run in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/agents/blob/master/docs/tutorials/1_dqn_tutorial.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003e\n",
-        "    View source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/agents/docs/tutorials/1_dqn_tutorial.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/agents/tutorials/1_dqn_tutorial\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
+        "    View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/agents/blob/master/docs/tutorials/1_dqn_tutorial.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
+        "    Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/agents/blob/master/docs/tutorials/1_dqn_tutorial.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+        "    View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/agents/docs/tutorials/1_dqn_tutorial.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -746,6 +746,19 @@
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "> **Note (Drivers):** This data collection loop is called a **Driver** in TF-Agents. Drivers implement this pattern so you don’t have to write it from scratch. See the **Drivers tutorial** and the **Drivers API** for details and alternatives like `DynamicStepDriver` and `DynamicEpisodeDriver`.\n",
+        "\n",
+        "- Drivers tutorial: https://www.tensorflow.org/agents/tutorials/4_drivers_tutorial  \n",
+        "\n",
+        "- Drivers API: https://www.tensorflow.org/agents/api_docs/python/tf_agents/drivers/dynamic_step_driver\n"
+      ],
+      "metadata": {
+        "id": "33U8aV-zX0rz"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "rVD5nQ9ZGo8_"
       },
@@ -999,10 +1012,10 @@
         "  video = open(filename,'rb').read()\n",
         "  b64 = base64.b64encode(video)\n",
         "  tag = '''\n",
-        "  \u003cvideo width=\"640\" height=\"480\" controls\u003e\n",
-        "    \u003csource src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\"\u003e\n",
+        "  <video width=\"640\" height=\"480\" controls>\n",
+        "    <source src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\">\n",
         "  Your browser does not support the video tag.\n",
-        "  \u003c/video\u003e'''.format(b64.decode())\n",
+        "  </video>'''.format(b64.decode())\n",
         "\n",
         "  return IPython.display.HTML(tag)"
       ]

--- a/docs/tutorials/1_dqn_tutorial.ipynb
+++ b/docs/tutorials/1_dqn_tutorial.ipynb
@@ -747,7 +747,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "> **Note (Drivers):** This data collection loop is called a **Driver** in TF-Agents. Drivers implement this pattern so you don’t have to write it from scratch. See the **Drivers tutorial** and the **Drivers API** for details and alternatives like `DynamicStepDriver` and `DynamicEpisodeDriver`.\n",
+        " **Note (Drivers):** This data collection loop is called a **Driver** in TF-Agents. Drivers implement this pattern so you don’t have to write it from scratch. See the **Drivers tutorial** and the **Drivers API** for details and alternatives like `DynamicStepDriver` and `DynamicEpisodeDriver`.\n",
         "\n",
         "- Drivers tutorial: https://www.tensorflow.org/agents/tutorials/4_drivers_tutorial  \n",
         "\n",


### PR DESCRIPTION
What
- Add a brief note that the data-collection loop is a Driver and link to the Drivers tutorial + API.

Why
- Aligns terminology for beginners and directs readers to the dedicated Drivers tutorial, per issue #554.

How verified
- Opened the notebook in Colab; markdown renders as expected; no code changes.

Links
- Fixes #554
